### PR TITLE
New logic in row selection of tables and issue fixes

### DIFF
--- a/app/scripts/views/chartGroupTemplate.js
+++ b/app/scripts/views/chartGroupTemplate.js
@@ -113,9 +113,7 @@
         this.chartInvisible.filter([_sampleIds]);
         this.$dispatch('update-all-filters', this.type);
       },
-      'update-samples-from-table':function(_sampleIds) {
-        //this.chartInvisible.filter(null);
-       // this.chartInvisible.filter([_sampleIds]);
+      'update-samples-from-table':function() {
         this.$dispatch('update-all-filters', this.type);
       }
     },

--- a/app/scripts/views/chartGroupTemplate.js
+++ b/app/scripts/views/chartGroupTemplate.js
@@ -114,8 +114,8 @@
         this.$dispatch('update-all-filters', this.type);
       },
       'update-samples-from-table':function(_sampleIds) {
-        this.chartInvisible.filter(null);
-        this.chartInvisible.filter([_sampleIds]);
+        //this.chartInvisible.filter(null);
+       // this.chartInvisible.filter([_sampleIds]);
         this.$dispatch('update-all-filters', this.type);
       }
     },

--- a/app/scripts/views/components/dataTable/MutatedGeneCNATable.js
+++ b/app/scripts/views/components/dataTable/MutatedGeneCNATable.js
@@ -2,1352 +2,1460 @@
 
 var EnhancedFixedDataTableSpecial = (function() {
 // Data button component
-    var FileGrabber = React.createClass({displayName: "FileGrabber",
-        // Saves table content to a text file
-        saveFile: function() {
-            var formatData = this.state.formatData || this.props.content();
-            this.state.formatData = formatData;
+  var FileGrabber = React.createClass({displayName: "FileGrabber",
+    // Saves table content to a text file
+    saveFile: function() {
+      var formatData = this.state.formatData || this.props.content();
+      this.state.formatData = formatData;
 
-            var blob = new Blob([formatData], {type: 'text/plain'});
-            var fileName = this.props.downloadFileName ? this.props.downloadFileName : "data.txt";
+      var blob = new Blob([formatData], {type: 'text/plain'});
+      var fileName = this.props.downloadFileName ? this.props.downloadFileName : "data.txt";
 
-            var downloadLink = document.createElement("a");
-            downloadLink.download = fileName;
-            downloadLink.innerHTML = "Download File";
-            if (window.webkitURL) {
-                // Chrome allows the link to be clicked
-                // without actually adding it to the DOM.
-                downloadLink.href = window.webkitURL.createObjectURL(blob);
-            }
-            else {
-                // Firefox requires the link to be added to the DOM
-                // before it can be clicked.
-                downloadLink.href = window.URL.createObjectURL(blob);
-                downloadLink.onclick = function(event) {
-                    document.body.removeChild(event.target);
-                };
-                downloadLink.style.display = "none";
-                document.body.appendChild(downloadLink);
-            }
+      var downloadLink = document.createElement("a");
+      downloadLink.download = fileName;
+      downloadLink.innerHTML = "Download File";
+      if (window.webkitURL) {
+        // Chrome allows the link to be clicked
+        // without actually adding it to the DOM.
+        downloadLink.href = window.webkitURL.createObjectURL(blob);
+      }
+      else {
+        // Firefox requires the link to be added to the DOM
+        // before it can be clicked.
+        downloadLink.href = window.URL.createObjectURL(blob);
+        downloadLink.onclick = function(event) {
+          document.body.removeChild(event.target);
+        };
+        downloadLink.style.display = "none";
+        document.body.appendChild(downloadLink);
+      }
 
-            downloadLink.click();
-        },
+      downloadLink.click();
+    },
 
-        getInitialState: function() {
-            return {
-                formatData: ''
-            };
-        },
+    getInitialState: function() {
+      return {
+        formatData: ''
+      };
+    },
 
-        render: function() {
-            return (
-              React.createElement("button", {className: "btn btn-default", onClick: this.saveFile},
-                "DATA")
-            );
-        }
-    });
+    render: function() {
+      return (
+        React.createElement("button", {className: "btn btn-default", onClick: this.saveFile},
+          "DATA")
+      );
+    }
+  });
 
 // Copy button component
-    var ClipboardGrabber = React.createClass({displayName: "ClipboardGrabber",
-        click: function() {
-            if (!this.state.formatData) {
-                var client = new ZeroClipboard($("#copy-button")), content = this.props.content();
-                this.state.formatData = content;
-                client.on("ready", function(readyEvent) {
-                    client.on("copy", function(event) {
-                        event.clipboardData.setData('text/plain', content);
-                    });
-                });
-            }
-            this.notify();
-        },
+  var ClipboardGrabber = React.createClass({displayName: "ClipboardGrabber",
+    click: function() {
+      if (!this.state.formatData) {
+        var client = new ZeroClipboard($("#copy-button")), content = this.props.content();
+        this.state.formatData = content;
+        client.on("ready", function(readyEvent) {
+          client.on("copy", function(event) {
+            event.clipboardData.setData('text/plain', content);
+          });
+        });
+      }
+      this.notify();
+    },
 
-        notify: function() {
-            $.notify({
-                message: 'Copied.'
-            }, {
-                type: 'success',
-                animate: {
-                    enter: 'animated fadeInDown',
-                    exit: 'animated fadeOutUp'
-                },
-                delay: 1000
-            });
+    notify: function() {
+      $.notify({
+        message: 'Copied.'
+      }, {
+        type: 'success',
+        animate: {
+          enter: 'animated fadeInDown',
+          exit: 'animated fadeOutUp'
         },
+        delay: 1000
+      });
+    },
 
-        getInitialState: function() {
-            return {
-                formatData: ''
-            };
-        },
+    getInitialState: function() {
+      return {
+        formatData: ''
+      };
+    },
 
-        render: function() {
-            return (
-              React.createElement("button", {className: "btn btn-default", id: "copy-button",
-                    onClick: this.click},
-                "COPY")
-            );
-        }
-    });
+    render: function() {
+      return (
+        React.createElement("button", {className: "btn btn-default", id: "copy-button",
+            onClick: this.click},
+          "COPY")
+      );
+    }
+  });
 
 // Container of FileGrabber and ClipboardGrabber
-    var DataGrabber = React.createClass({displayName: "DataGrabber",
-        // Prepares table content data for download or copy button
-        prepareContent: function() {
-            var content = [], cols = this.props.cols, rows = this.props.rows;
+  var DataGrabber = React.createClass({displayName: "DataGrabber",
+    // Prepares table content data for download or copy button
+    prepareContent: function() {
+      var content = [], cols = this.props.cols, rows = this.props.rows;
 
-            _.each(cols, function(e) {
-                content.push((e.displayName || 'Unknown'), '\t');
-            });
-            content.pop();
+      _.each(cols, function(e) {
+        content.push((e.displayName || 'Unknown'), '\t');
+      });
+      content.pop();
 
-            _.each(rows, function(row) {
-                content.push('\r\n');
-                _.each(cols, function(col) {
-                    content.push(row[col.name], '\t');
-                });
-                content.pop();
-            });
-            return content.join('');
-        },
+      _.each(rows, function(row) {
+        content.push('\r\n');
+        _.each(cols, function(col) {
+          content.push(row[col.name], '\t');
+        });
+        content.pop();
+      });
+      return content.join('');
+    },
 
-        render: function() {
-            var getData = this.props.getData;
-            if (getData === "NONE") {
-                return React.createElement("div", null);
-            }
+    render: function() {
+      var getData = this.props.getData;
+      if (getData === "NONE") {
+        return React.createElement("div", null);
+      }
 
-            var content = this.prepareContent;
+      var content = this.prepareContent;
 
-            return (
-              React.createElement("div", null,
-                React.createElement("div", {className: "EFDT-download-btn EFDT-top-btn"},
+      return (
+        React.createElement("div", null,
+          React.createElement("div", {className: "EFDT-download-btn EFDT-top-btn"},
 
-                  getData != "COPY" ? React.createElement(FileGrabber, {content: content,
-                      downloadFileName: this.props.downloadFileName}) :
-                    React.createElement("div", null)
+            getData != "COPY" ? React.createElement(FileGrabber, {content: content,
+              downloadFileName: this.props.downloadFileName}) :
+              React.createElement("div", null)
 
-                ),
-                React.createElement("div", {className: "EFDT-download-btn EFDT-top-btn"},
+          ),
+          React.createElement("div", {className: "EFDT-download-btn EFDT-top-btn"},
 
-                  getData != "DOWNLOAD" ? React.createElement(ClipboardGrabber, {content: content}) :
-                    React.createElement("div", null)
+            getData != "DOWNLOAD" ? React.createElement(ClipboardGrabber, {content: content}) :
+              React.createElement("div", null)
 
-                )
-              )
-            );
-        }
-    });
+          )
+        )
+      );
+    }
+  });
 
 // Wrapper of qTip for string
 // Generates qTip when string length is larger than 20
-    var QtipWrapper = React.createClass({displayName: "QtipWrapper",
-        render: function() {
-            var label = this.props.label, qtipFlag = false;
-            var shortLabel = this.props.shortLabel;
-            var className = this.props.className || '';
-            var field = this.props.field;
-            var color = this.props.color || '';
-            var tableType = this.props.tableType || '';
+  var QtipWrapper = React.createClass({displayName: "QtipWrapper",
+    render: function() {
+      var label = this.props.label, qtipFlag = false;
+      var shortLabel = this.props.shortLabel;
+      var className = this.props.className || '';
+      var field = this.props.field;
+      var color = this.props.color || '';
+      var tableType = this.props.tableType || '';
 
-            if (label && shortLabel && label.toString().length > shortLabel.toString().length) {
-                qtipFlag = true;
-            }
-            return (
-              React.createElement("span", {className: className + (qtipFlag?" hasQtip " : '') +
-                ((field === 'altType' && ['mutatedGene', 'cna'].indexOf(tableType) !== -1) ? (label === 'AMP' ? ' alt-type-red' : ' alt-type-blue') : ''),
-                    "data-qtip": label},
+      if (label && shortLabel && label.toString().length > shortLabel.toString().length) {
+        qtipFlag = true;
+      }
+      return (
+        React.createElement("span", {className: className + (qtipFlag?" hasQtip " : '') +
+          ((field === 'altType' && ['mutatedGene', 'cna'].indexOf(tableType) !== -1) ? (label === 'AMP' ? ' alt-type-red' : ' alt-type-blue') : ''),
+            "data-qtip": label},
 
-                (field === 'name' && tableType === 'pieLabel') ? (
-                  React.createElement("svg", {width: "15", height: "10"},
-                    React.createElement("g", null,
-                      React.createElement("rect", {height: "10", width: "10", fill: color})
-                    )
-                  )
-                ) : '',
-
-                shortLabel
+          (field === 'name' && tableType === 'pieLabel') ? (
+            React.createElement("svg", {width: "15", height: "10"},
+              React.createElement("g", null,
+                React.createElement("rect", {height: "10", width: "10", fill: color})
               )
-            );
-        }
-    });
+            )
+          ) : '',
+
+          shortLabel
+        )
+      );
+    }
+  });
 
 // Column show/hide component
-    var ColumnHider = React.createClass({displayName: "ColumnHider",
-        tableCols: [],// For the checklist
+  var ColumnHider = React.createClass({displayName: "ColumnHider",
+    tableCols: [],// For the checklist
 
-        // Updates column show/hide settings
-        hideColumns: function(list) {
-            var cols = this.props.cols, filters = this.props.filters;
-            for (var i = 0; i < list.length; i++) {
-                cols[i].show = list[i].isChecked;
-                if (this.props.hideFilter) {
-                    filters[cols[i].name].hide = !cols[i].show;
-                }
-            }
-            this.props.updateCols(cols, filters);
-        },
-
-        // Prepares tableCols
-        componentWillMount: function() {
-            var cols = this.props.cols;
-            var colsL = cols.length;
-            for (var i = 0; i < colsL; i++) {
-                this.tableCols.push({
-                    id: cols[i].name,
-                    label: cols[i].displayName,
-                    isChecked: cols[i].show
-                });
-            }
-        },
-
-        componentDidMount: function() {
-            var hideColumns = this.hideColumns;
-
-            // Dropdown checklist
-            $('#hide_column_checklist')
-              .dropdownCheckbox({
-                  data: this.tableCols,
-                  autosearch: true,
-                  title: "Show / Hide Columns",
-                  hideHeader: false,
-                  showNbSelected: true
-              })
-              // Handles dropdown checklist event
-              .on("change", function() {
-                  var list = ($("#hide_column_checklist").dropdownCheckbox("items"));
-                  hideColumns(list);
-              });
-        },
-
-        render: function() {
-            return (
-              React.createElement("div", {id: "hide_column_checklist", className: "EFDT-top-btn"})
-            );
+    // Updates column show/hide settings
+    hideColumns: function(list) {
+      var cols = this.props.cols, filters = this.props.filters;
+      for (var i = 0; i < list.length; i++) {
+        cols[i].show = list[i].isChecked;
+        if (this.props.hideFilter) {
+          filters[cols[i].name].hide = !cols[i].show;
         }
-    });
+      }
+      this.props.updateCols(cols, filters);
+    },
+
+    // Prepares tableCols
+    componentWillMount: function() {
+      var cols = this.props.cols;
+      var colsL = cols.length;
+      for (var i = 0; i < colsL; i++) {
+        this.tableCols.push({
+          id: cols[i].name,
+          label: cols[i].displayName,
+          isChecked: cols[i].show
+        });
+      }
+    },
+
+    componentDidMount: function() {
+      var hideColumns = this.hideColumns;
+
+      // Dropdown checklist
+      $('#hide_column_checklist')
+        .dropdownCheckbox({
+          data: this.tableCols,
+          autosearch: true,
+          title: "Show / Hide Columns",
+          hideHeader: false,
+          showNbSelected: true
+        })
+        // Handles dropdown checklist event
+        .on("change", function() {
+          var list = ($("#hide_column_checklist").dropdownCheckbox("items"));
+          hideColumns(list);
+        });
+    },
+
+    render: function() {
+      return (
+        React.createElement("div", {id: "hide_column_checklist", className: "EFDT-top-btn"})
+      );
+    }
+  });
 
 // Choose fixed columns component
-    var PinColumns = React.createClass({displayName: "PinColumns",
-        tableCols: [],// For the checklist
+  var PinColumns = React.createClass({displayName: "PinColumns",
+    tableCols: [],// For the checklist
 
-        // Updates fixed column settings
-        pinColumns: function(list) {
-            var cols = this.props.cols;
-            for (var i = 0; i < list.length; i++) {
-                cols[i].fixed = list[i].isChecked;
-            }
-            this.props.updateCols(cols, this.props.filters);
-        },
+    // Updates fixed column settings
+    pinColumns: function(list) {
+      var cols = this.props.cols;
+      for (var i = 0; i < list.length; i++) {
+        cols[i].fixed = list[i].isChecked;
+      }
+      this.props.updateCols(cols, this.props.filters);
+    },
 
-        // Prepares tableCols
-        componentWillMount: function() {
-            var cols = this.props.cols;
-            var colsL = cols.length;
-            for (var i = 0; i < colsL; i++) {
-                this.tableCols.push({
-                    id: cols[i].name,
-                    label: cols[i].displayName,
-                    isChecked: cols[i].fixed
-                });
-            }
-        },
+    // Prepares tableCols
+    componentWillMount: function() {
+      var cols = this.props.cols;
+      var colsL = cols.length;
+      for (var i = 0; i < colsL; i++) {
+        this.tableCols.push({
+          id: cols[i].name,
+          label: cols[i].displayName,
+          isChecked: cols[i].fixed
+        });
+      }
+    },
 
-        componentDidMount: function() {
-            var pinColumns = this.pinColumns;
+    componentDidMount: function() {
+      var pinColumns = this.pinColumns;
 
-            // Dropdown checklist
-            $("#pin_column_checklist")
-              .dropdownCheckbox({
-                  data: this.tableCols,
-                  autosearch: true,
-                  title: "Choose Fixed Columns",
-                  hideHeader: false,
-                  showNbSelected: true
-              })
-              // Handles dropdown checklist event
-              .on("change", function() {
-                  var list = ($("#pin_column_checklist").dropdownCheckbox("items"));
-                  pinColumns(list);
-              });
-        },
+      // Dropdown checklist
+      $("#pin_column_checklist")
+        .dropdownCheckbox({
+          data: this.tableCols,
+          autosearch: true,
+          title: "Choose Fixed Columns",
+          hideHeader: false,
+          showNbSelected: true
+        })
+        // Handles dropdown checklist event
+        .on("change", function() {
+          var list = ($("#pin_column_checklist").dropdownCheckbox("items"));
+          pinColumns(list);
+        });
+    },
 
-        render: function() {
-            return (
-              React.createElement("div", {id: "pin_column_checklist", className: "EFDT-top-btn"})
-            );
-        }
-    });
+    render: function() {
+      return (
+        React.createElement("div", {id: "pin_column_checklist", className: "EFDT-top-btn"})
+      );
+    }
+  });
 
 // Column scroller component
-    var ColumnScroller = React.createClass({displayName: "ColumnScroller",
-        // Scrolls to user selected column
-        scrollToColumn: function(e) {
-            var name = e.target.value, cols = this.props.cols, index, colsL = cols.length;
-            for (var i = 0; i < colsL; i++) {
-                if (name === cols[i].name) {
-                    index = i;
-                    break;
-                }
-            }
-            this.props.updateGoToColumn(index);
-        },
+  var ColumnScroller = React.createClass({displayName: "ColumnScroller",
+    // Scrolls to user selected column
+    scrollToColumn: function(e) {
+      var name = e.target.value, cols = this.props.cols, index, colsL = cols.length;
+      for (var i = 0; i < colsL; i++) {
+        if (name === cols[i].name) {
+          index = i;
+          break;
+        }
+      }
+      this.props.updateGoToColumn(index);
+    },
 
-        render: function() {
+    render: function() {
+      return (
+        React.createElement(Chosen, {"data-placeholder": "Column Scroller",
+            onChange: this.scrollToColumn},
+
+          this.props.cols.map(function(col) {
             return (
-              React.createElement(Chosen, {"data-placeholder": "Column Scroller",
-                    onChange: this.scrollToColumn},
-
-                this.props.cols.map(function(col) {
-                    return (
-                      React.createElement("option", {title: col.displayName, value: col.name},
-                        React.createElement(QtipWrapper, {label: col.displayName})
-                      )
-                    );
-                })
-
+              React.createElement("option", {title: col.displayName, value: col.name},
+                React.createElement(QtipWrapper, {label: col.displayName})
               )
             );
-        }
-    });
+          })
+
+        )
+      );
+    }
+  });
 
 // Filter component
-    var Filter = React.createClass({displayName: "Filter",
-        getInitialState: function() {
-            return {key: ''};
-        },
-        handleChange: function(event) {
-            this.setState({key: event.target.value});
-            this.props.onFilterKeywordChange(event);
-        },
-        componentWillUpdate: function() {
-            if (this.props.type === 'STRING') {
-                if (!_.isUndefined(this.props.filter) && this.props.filter.key !== this.state.key && this.props.filter.key === '' && this.props.filter.reset) {
-                    this.state.key = '';
-                    this.props.filter.reset = false;
-                }
-            }
-        },
-        render: function() {
-            if (this.props.type === "NUMBER" || this.props.type === "PERCENTAGE") {
-                return (
-                  React.createElement("div", {className: "EFDT-header-filters"},
-                    React.createElement("span", {id: "range-"+this.props.name}),
-
-                    React.createElement("div", {className: "rangeSlider", "data-max": this.props.max,
-                        "data-min": this.props.min, "data-column": this.props.name,
-                        "data-type": this.props.type})
-                  )
-                );
-            } else {
-                return (
-                  React.createElement("div", {className: "EFDT-header-filters"},
-                    React.createElement("input", {className: "form-control",
-                        placeholder: this.props.hasOwnProperty('placeholder')?this.props.placeholder:"Search...",
-                        "data-column": this.props.name,
-                        value: this.state.key,
-                        onChange: this.handleChange})
-                  )
-                );
-            }
+  var Filter = React.createClass({displayName: "Filter",
+    getInitialState: function() {
+      return {key: ''};
+    },
+    handleChange: function(event) {
+      this.setState({key: event.target.value});
+      this.props.onFilterKeywordChange(event);
+    },
+    componentWillUpdate: function() {
+      if (this.props.type === 'STRING') {
+        if (!_.isUndefined(this.props.filter) && this.props.filter.key !== this.state.key && this.props.filter.key === '' && this.props.filter.reset) {
+          this.state.key = '';
+          this.props.filter.reset = false;
         }
-    });
+      }
+    },
+    render: function() {
+      if (this.props.type === "NUMBER" || this.props.type === "PERCENTAGE") {
+        return (
+          React.createElement("div", {className: "EFDT-header-filters"},
+            React.createElement("span", {id: "range-"+this.props.name}),
+
+            React.createElement("div", {className: "rangeSlider", "data-max": this.props.max,
+              "data-min": this.props.min, "data-column": this.props.name,
+              "data-type": this.props.type})
+          )
+        );
+      } else {
+        return (
+          React.createElement("div", {className: "EFDT-header-filters"},
+            React.createElement("input", {className: "form-control",
+              placeholder: this.props.hasOwnProperty('placeholder')?this.props.placeholder:"Search...",
+              "data-column": this.props.name,
+              value: this.state.key,
+              onChange: this.handleChange})
+          )
+        );
+      }
+    }
+  });
 
 // Table prefix component
 // Contains components above the main part of table
-    var TablePrefix = React.createClass({displayName: "TablePrefix",
-        render: function() {
-            return (
-              React.createElement("div", null,
-                React.createElement("div", null,
+  var TablePrefix = React.createClass({displayName: "TablePrefix",
+    render: function() {
+      return (
+        React.createElement("div", null,
+          React.createElement("div", null,
 
-                  this.props.hider ?
-                    React.createElement("div", {className: "EFDT-show-hide"},
-                      React.createElement(ColumnHider, {cols: this.props.cols,
-                          filters: this.props.filters,
-                          hideFilter: this.props.hideFilter,
-                          updateCols: this.props.updateCols})
-                    ) :
-                    "",
+            this.props.hider ?
+              React.createElement("div", {className: "EFDT-show-hide"},
+                React.createElement(ColumnHider, {cols: this.props.cols,
+                  filters: this.props.filters,
+                  hideFilter: this.props.hideFilter,
+                  updateCols: this.props.updateCols})
+              ) :
+              "",
 
 
-                  this.props.fixedChoose ?
-                    React.createElement("div", {className: "EFDT-fixed-choose"},
-                      React.createElement(PinColumns, {cols: this.props.cols,
-                          filters: this.props.filters,
-                          updateCols: this.props.updateCols})
-                    ) :
-                    "",
+            this.props.fixedChoose ?
+              React.createElement("div", {className: "EFDT-fixed-choose"},
+                React.createElement(PinColumns, {cols: this.props.cols,
+                  filters: this.props.filters,
+                  updateCols: this.props.updateCols})
+              ) :
+              "",
 
-                  React.createElement("div", {className: "EFDT-download"},
-                    React.createElement(DataGrabber, {cols: this.props.cols, rows: this.props.rows,
-                        downloadFileName: this.props.downloadFileName,
-                        getData: this.props.getData})
-                  ),
+            React.createElement("div", {className: "EFDT-download"},
+              React.createElement(DataGrabber, {cols: this.props.cols, rows: this.props.rows,
+                downloadFileName: this.props.downloadFileName,
+                getData: this.props.getData})
+            ),
 
-                  this.props.resultInfo ?
-                    React.createElement("div", {className: "EFDT-result-info"},
-                      React.createElement("span", {className: "EFDT-result-info-content"},
-                        "Showing ", this.props.filteredRowsSize, " samples",
+            this.props.resultInfo ?
+              React.createElement("div", {className: "EFDT-result-info"},
+                React.createElement("span", {className: "EFDT-result-info-content"},
+                  "Showing ", this.props.filteredRowsSize, " samples",
 
-                        this.props.filteredRowsSize !== this.props.rowsSize ?
-                          React.createElement("span", null, ' (filtered from ' + this.props.rowsSize + ') ',
-                            React.createElement("span", {className: "EFDT-header-filters-reset",
-                                onClick: this.props.onResetFilters}, "Reset")
-                          )
-                          : ''
+                  this.props.filteredRowsSize !== this.props.rowsSize ?
+                    React.createElement("span", null, ' (filtered from ' + this.props.rowsSize + ') ',
+                      React.createElement("span", {className: "EFDT-header-filters-reset",
+                        onClick: this.props.onResetFilters}, "Reset")
+                    )
+                    : ''
 
-                      )
-                    ) :
-                    ""
-
-                ),
-                React.createElement("div", null
                 )
-              )
-            );
-        }
-    });
+              ) :
+              ""
+
+          ),
+          React.createElement("div", null
+          )
+        )
+      );
+    }
+  });
 
 // Wrapper for the header rendering
-    var HeaderWrapper = React.createClass({displayName: "HeaderWrapper",
-        render: function() {
-            var columnData = this.props.columnData;
-            var shortLabel = this.props.shortLabel;
-            return (
-              React.createElement("div", {className: "EFDT-header"},
-                React.createElement("span", {className: "EFDT-header-sort", href: "#",
-                      onClick: this.props.sortNSet.bind(null, this.props.cellDataKey)},
-                  React.createElement(QtipWrapper, {label: columnData.displayName,
-                      shortLabel: shortLabel,
-                      className: 'EFDT-header-sort-content'}),
-                  columnData.sortFlag ?
-                    React.createElement("div", {
-                        className: columnData.sortDirArrow + ' EFDT-header-sort-icon'})
-                    : ""
-                )
-              )
-            );
-        }
-    });
+  var HeaderWrapper = React.createClass({displayName: "HeaderWrapper",
+    render: function() {
+      var columnData = this.props.columnData;
+      var shortLabel = this.props.shortLabel;
+      return (
+        React.createElement("div", {className: "EFDT-header"},
+          React.createElement("span", {className: "EFDT-header-sort", href: "#",
+              onClick: this.props.sortNSet.bind(null, this.props.cellDataKey)},
+            React.createElement(QtipWrapper, {label: columnData.displayName,
+              shortLabel: shortLabel,
+              className: 'EFDT-header-sort-content'}),
+            columnData.sortFlag ?
+              React.createElement("div", {
+                className: columnData.sortDirArrow + ' EFDT-header-sort-icon'})
+              : ""
+          )
+        )
+      );
+    }
+  });
 
-    var CustomizeCell = React.createClass({displayName: "CustomizeCell",
-        selectRow: function(rowIndex) {
-            this.props.selectRow(rowIndex);
-        },
-        selectGene: function(rowIndex) {
-            this.props.selectGene(rowIndex);
-        },
-        enterPieLabel: function(data) {
-            this.props.pieLabelMouseEnterFunc(data);
-        },
-        leavePieLabel: function(data) {
-            this.props.pieLabelMouseLeaveFunc(data);
-        },
-        render: function() {
-            var Cell = FixedDataTable.Cell;
-            var rowIndex = this.props.rowIndex, data = this.props.data, field = this.props.field, filterAll = this.props.filterAll;
-            var flag = (data[rowIndex][field] && filterAll.length > 0) ?
-              (data[rowIndex][field].toLowerCase().indexOf(filterAll.toLowerCase()) >= 0) : false;
-            var shortLabels = this.props.shortLabels;
-            var tableType = this.props.tableType;
-            return (
-              React.createElement(Cell, {onFocus: this.onFocus, className: 'EFDT-cell EFDT-cell-full' +
-                (this.props.selectedRowIndex.indexOf(data[rowIndex].index) != -1 ? ' row-selected' : ''),
-                    columnKey: field},
-                React.createElement("span", {style: flag ? {backgroundColor:'yellow'} : {},
-                      onClick: field === 'gene' ? this.selectGene.bind(this, data[rowIndex].index) : '',
-                      onMouseEnter: (tableType === 'pieLabel' && _.isFunction(this.props.pieLabelMouseEnterFunc) && field === 'name') ? this.enterPieLabel.bind(this, data[rowIndex].row) : '',
-                      onMouseLeave: (tableType === 'pieLabel' && _.isFunction(this.props.pieLabelMouseLeaveFunc) && field === 'name') ? this.leavePieLabel.bind(this, data[rowIndex].row) : '',
-                      "data-qtip": field === 'gene' ? ('Click ' + data[rowIndex].row[field] + ' to ' + ( this.props.selectedGeneRowIndex.indexOf(data[rowIndex].index) === -1 ? 'add to ' : ' remove from ' ) + 'your query') : '',
-                      className: (field === 'gene' ? 'gene hasQtip' : '') +
-                      ((field === 'gene' && this.props.selectedGeneRowIndex.indexOf(data[rowIndex].index) != -1) ? ' gene-selected' : '')},
-                  React.createElement(QtipWrapper, {label: data[rowIndex].row[field],
-                      shortLabel: shortLabels[data[rowIndex].index][field],
-                      field: field,
-                      tableType: tableType,
-                      color: data[rowIndex].row.color})
-                ),
+  var CustomizeCell = React.createClass({displayName: "CustomizeCell",
+    selectRow: function(rowIndex) {
+      this.props.selectRow(rowIndex);
+    },
+    selectGene: function(rowIndex) {
+      this.props.selectGene(rowIndex);
+    },
+    enterPieLabel: function(data) {
+      this.props.pieLabelMouseEnterFunc(data);
+    },
+    leavePieLabel: function(data) {
+      this.props.pieLabelMouseLeaveFunc(data);
+    },
+    render: function() {
+      var Cell = FixedDataTable.Cell;
+      var rowIndex = this.props.rowIndex, data = this.props.data, field = this.props.field, filterAll = this.props.filterAll;
+      var flag = (data[rowIndex][field] && filterAll.length > 0) ?
+        (data[rowIndex][field].toLowerCase().indexOf(filterAll.toLowerCase()) >= 0) : false;
+      var shortLabels = this.props.shortLabels;
+      var tableType = this.props.tableType;
+      var confirmedRowsIndex = this.props.confirmedRowsIndex;
+      return (
+        React.createElement(Cell, {onFocus: this.onFocus, className: 'EFDT-cell EFDT-cell-full' +
+          (this.props.selectedRowIndex.indexOf(data[rowIndex].index) != -1 ? ' row-selected' : ''),
+            columnKey: field},
+          React.createElement("span", {style: flag ? {backgroundColor:'yellow'} : {},
+              onClick: field === 'gene' ? this.selectGene.bind(this, data[rowIndex].index) : '',
+              onMouseEnter: (tableType === 'pieLabel' && _.isFunction(this.props.pieLabelMouseEnterFunc) && field === 'name') ? this.enterPieLabel.bind(this, data[rowIndex].row) : '',
+              onMouseLeave: (tableType === 'pieLabel' && _.isFunction(this.props.pieLabelMouseLeaveFunc) && field === 'name') ? this.leavePieLabel.bind(this, data[rowIndex].row) : '',
+              "data-qtip": field === 'gene' ? ('Click ' + data[rowIndex].row[field] + ' to ' + ( this.props.selectedGeneRowIndex.indexOf(data[rowIndex].index) === -1 ? 'add to ' : ' remove from ' ) + 'your query') : '',
+              className: (field === 'gene' ? 'gene hasQtip' : '') +
+              ((field === 'gene' && this.props.selectedGeneRowIndex.indexOf(data[rowIndex].index) != -1) ? ' gene-selected' : '')},
+            React.createElement(QtipWrapper, {label: data[rowIndex].row[field],
+              shortLabel: shortLabels[data[rowIndex].index][field],
+              field: field,
+              tableType: tableType,
+              color: data[rowIndex].row.color})
+          ),
 
-                field === 'gene' && data[rowIndex].row.qval ?
-                  (tableType === 'mutatedGene' ?
-                    React.createElement("img", {src: "images/mutsig.png", className: "hasQtip qval-icon",
-                        "data-qtip": '<b>MutSig</b><br/><i>Q-value</i>: ' + data[rowIndex].row.qval}) :
-                    React.createElement("img", {src: "images/gistic.png", className: "hasQtip qval-icon",
-                        "data-qtip": '<b>Gistic</b><br/><i>Q-value</i>: ' + data[rowIndex].row.qval})) : '',
+          field === 'gene' && data[rowIndex].row.qval ?
+            (tableType === 'mutatedGene' ?
+              React.createElement("img", {src: "images/mutsig.png", className: "hasQtip qval-icon",
+                "data-qtip": '<b>MutSig</b><br/><i>Q-value</i>: ' + data[rowIndex].row.qval}) :
+              React.createElement("img", {src: "images/gistic.png", className: "hasQtip qval-icon",
+                "data-qtip": '<b>Gistic</b><br/><i>Q-value</i>: ' + data[rowIndex].row.qval})) : '',
 
 
-                field === 'samples' ?
-                  React.createElement("input", {type: "checkbox", style: {float: 'right'},
-                      checked: this.props.selectedRowIndex.indexOf(data[rowIndex].index) != -1,
-                      onChange: this.selectRow.bind(this, data[rowIndex].index)}) : ''
+          field === 'samples' ?
+            React.createElement("input", {type: "checkbox", style: {float: 'right'},
+              title: 'Select ' + data[rowIndex].row[field]
+              + ' sample' + (Number(data[rowIndex].row[field]) > 1 ? 's':'')
+              + (tableType === 'mutatedGene' ? (' with ' + data[rowIndex].row.gene + ' mutation') :
+                (tableType === 'cna' ? (' with ' + data[rowIndex].row.gene + ' ' + data[rowIndex].row.altType) :
+                  (tableType === 'pieLabel' ? (' in ' + data[rowIndex].row.name)  : ''))),
+              checked: this.props.selectedRowIndex.indexOf(data[rowIndex].index) != -1,
+              disabled: this.props.confirmedRowsIndex.indexOf(data[rowIndex].index) !== -1,
+              onChange: this.selectRow.bind(this, data[rowIndex].index)}) : ''
 
-              )
-            );
-        }
-    });
+        )
+      );
+    }
+  });
 
 // Main part table component
 // Uses FixedDataTable library
-    var TableMainPart = React.createClass({displayName: "TableMainPart",
-        // Creates Qtip
-        createQtip: function() {
-            $('.EFDT-table .hasQtip').one('mouseenter', function() {
-                $(this).qtip({
-                    content: {text: $(this).attr('data-qtip')},
-                    hide: {fixed: true, delay: 100},
-                    show: {ready: true},
-                    style: {classes: 'qtip-light qtip-rounded qtip-shadow', tip: true},
-                    position: {my: 'center left', at: 'center right', viewport: $(window)}
-                });
-            });
-        },
+  var TableMainPart = React.createClass({displayName: "TableMainPart",
+    // Creates Qtip
+    createQtip: function() {
+      $('.EFDT-table .hasQtip').one('mouseenter', function() {
+        $(this).qtip({
+          content: {text: $(this).attr('data-qtip')},
+          hide: {fixed: true, delay: 100},
+          show: {ready: true},
+          style: {classes: 'qtip-light qtip-rounded qtip-shadow', tip: true},
+          position: {my: 'center left', at: 'center right', viewport: $(window)}
+        });
+      });
+    },
 
-        // Creates Qtip after first rendering
-        componentDidMount: function() {
-            this.createQtip();
-        },
+    // Creates Qtip after first rendering
+    componentDidMount: function() {
+      this.createQtip();
+    },
 
-        // Creates Qtip after update rendering
-        componentDidUpdate: function() {
-            this.createQtip();
-        },
+    // Creates Qtip after update rendering
+    componentDidUpdate: function() {
+      this.createQtip();
+    },
 
-        // Creates Qtip after page scrolling
-        onScrollEnd: function() {
-            $(".qtip").remove();
-            this.createQtip();
-        },
+    // Creates Qtip after page scrolling
+    onScrollEnd: function() {
+      $(".qtip").remove();
+      this.createQtip();
+    },
 
-        // Destroys Qtip before update rendering
-        componentWillUpdate: function() {
-            //console.log('number of elments which has "hasQtip" as class name: ', $('.hasQtip').size());
-            //console.log('number of elments which has "hasQtip" as class name under class EFDT: ', $('.EFDT-table .hasQtip').size());
+    // Destroys Qtip before update rendering
+    componentWillUpdate: function() {
+      //console.log('number of elments which has "hasQtip" as class name: ', $('.hasQtip').size());
+      //console.log('number of elments which has "hasQtip" as class name under class EFDT: ', $('.EFDT-table .hasQtip').size());
 
-            $('.EFDT-table .hasQtip')
-              .each(function() {
-                  $(this).qtip('destroy', true);
-              });
-        },
+      $('.EFDT-table .hasQtip')
+        .each(function() {
+          $(this).qtip('destroy', true);
+        });
+    },
 
-        getDefaultProps: function() {
-            return {
-                selectedRowIndex: []
-            };
-        },
+    getDefaultProps: function() {
+      return {
+        selectedRowIndex: []
+      };
+    },
 
-        getInitialState: function() {
-            return {
-                selectedRowIndex: this.props.selectedRowIndex,
-                selectedGeneRowIndex: this.props.selectedGeneRowIndex
-            }
-        },
+    getInitialState: function() {
+      return {
+        selectedRowIndex: this.props.selectedRowIndex,
+        selectedGeneRowIndex: this.props.selectedGeneRowIndex
+      }
+    },
 
-        selectRow: function(rowIndex) {
-            var selectedRowIndex = this.state.selectedRowIndex;
-            var selected = false;
-            var rows = this.props.rows;
-            if ((_.intersection(selectedRowIndex, [rowIndex])).length > 0) {
-                selectedRowIndex = _.without(selectedRowIndex, rowIndex);
-            } else {
-                selectedRowIndex.push(rowIndex);
-                selected = true;
-            }
+    selectRow: function(rowIndex) {
+      var selectedRowIndex = this.state.selectedRowIndex;
+      var selected = false;
+      var rows = this.props.rows;
+      if ((_.intersection(selectedRowIndex, [rowIndex])).length > 0) {
+        selectedRowIndex = _.without(selectedRowIndex, rowIndex);
+      } else {
+        selectedRowIndex.push(rowIndex);
+        selected = true;
+      }
 
-            if (_.isFunction(this.props.rowClickFunc)) {
-                var selectedData = selectedRowIndex.map(function(item) {
-                    return rows[item];
-                });
-                this.props.rowClickFunc(rows[rowIndex], selected, selectedData);
-            }
+      if (_.isFunction(this.props.rowClickFunc)) {
+        var selectedData = selectedRowIndex.map(function(item) {
+          return rows[item];
+        });
+        this.props.rowClickFunc(rows[rowIndex], selected, selectedData);
+      }
 
-            this.setState({
-                selectedRowIndex: selectedRowIndex
-            });
-        },
+      this.setState({
+        selectedRowIndex: selectedRowIndex
+      });
+    },
 
-        selectGene: function(rowIndex) {
-            var selectedGeneRowIndex = this.state.selectedGeneRowIndex;
-            var selected = false;
-            var rows = this.props.rows;
-            if ((_.intersection(selectedGeneRowIndex, [rowIndex])).length > 0) {
-                selectedGeneRowIndex = _.without(selectedGeneRowIndex, rowIndex);
-            } else {
-                selectedGeneRowIndex.push(rowIndex);
-                selected = true;
-            }
+    selectGene: function(rowIndex) {
+      var selectedGeneRowIndex = this.state.selectedGeneRowIndex;
+      var selected = false;
+      var rows = this.props.rows;
+      if ((_.intersection(selectedGeneRowIndex, [rowIndex])).length > 0) {
+        selectedGeneRowIndex = _.without(selectedGeneRowIndex, rowIndex);
+      } else {
+        selectedGeneRowIndex.push(rowIndex);
+        selected = true;
+      }
 
-            if (_.isFunction(this.props.geneClickFunc)) {
-                this.props.geneClickFunc(rows[rowIndex], selected);
-            }
+      if (_.isFunction(this.props.geneClickFunc)) {
+        this.props.geneClickFunc(rows[rowIndex], selected);
+      }
 
-            this.setState({
-                selectedGeneRowIndex: selectedGeneRowIndex
-            });
-        },
+      this.setState({
+        selectedGeneRowIndex: selectedGeneRowIndex
+      });
+    },
 
-        // If properties changed
-        componentWillReceiveProps: function(newProps) {
-            if (newProps.selectedRowIndex !== this.state.selectedRowIndex) {
-                this.setState({
-                    selectedRowIndex: newProps.selectedRowIndex
-                });
-            }
-            if (newProps.selectedGeneRowIndex !== this.state.selectedGeneRowIndex) {
-                this.setState({
-                    selectedGeneRowIndex: newProps.selectedGeneRowIndex
-                });
-            }
-        },
+    // If properties changed
+    componentWillReceiveProps: function(newProps) {
+      if (newProps.selectedRowIndex !== this.state.selectedRowIndex) {
+        this.setState({
+          selectedRowIndex: newProps.selectedRowIndex
+        });
+      }
+      if (newProps.selectedGeneRowIndex !== this.state.selectedGeneRowIndex) {
+        this.setState({
+          selectedGeneRowIndex: newProps.selectedGeneRowIndex
+        });
+      }
+    },
 
-        // FixedDataTable render function
-        render: function() {
-            var Table = FixedDataTable.Table, Column = FixedDataTable.Column,
-              ColumnGroup = FixedDataTable.ColumnGroup, props = this.props,
-              rows = this.props.filteredRows, columnWidths = this.props.columnWidths,
-              cellShortLabels = this.props.shortLabels.cell,
-              headerShortLabels = this.props.shortLabels.header,
-              selectedRowIndex = this.state.selectedRowIndex,
-              selectedGeneRowIndex = this.state.selectedGeneRowIndex,
-              self = this;
+    // FixedDataTable render function
+    render: function() {
+      var Table = FixedDataTable.Table, Column = FixedDataTable.Column,
+        ColumnGroup = FixedDataTable.ColumnGroup, props = this.props,
+        rows = this.props.filteredRows, columnWidths = this.props.columnWidths,
+        cellShortLabels = this.props.shortLabels.cell,
+        headerShortLabels = this.props.shortLabels.header,
+        confirmedRowsIndex=this.props.confirmedRowsIndex,
+        selectedRowIndex = this.state.selectedRowIndex,
+        selectedGeneRowIndex = this.state.selectedGeneRowIndex,
+        self = this;
 
-            return (
-              React.createElement("div", null,
-                React.createElement(Table, {
-                      rowHeight: props.rowHeight?props.rowHeight:30,
-                      rowGetter: this.rowGetter,
-                      onScrollEnd: this.onScrollEnd,
-                      rowsCount: props.filteredRows.length,
-                      width: props.tableWidth?props.tableWidth:1230,
-                      maxHeight: props.maxHeight?props.maxHeight:500,
-                      headerHeight: props.headerHeight?props.headerHeight:30,
-                      groupHeaderHeight: props.groupHeaderHeight?props.groupHeaderHeight:50,
-                      scrollToColumn: props.goToColumn
+      return (
+        React.createElement("div", null,
+          React.createElement(Table, {
+              rowHeight: props.rowHeight?props.rowHeight:30,
+              rowGetter: this.rowGetter,
+              onScrollEnd: this.onScrollEnd,
+              rowsCount: props.filteredRows.length,
+              width: props.tableWidth?props.tableWidth:1230,
+              maxHeight: props.maxHeight?props.maxHeight:500,
+              headerHeight: props.headerHeight?props.headerHeight:30,
+              groupHeaderHeight: props.groupHeaderHeight?props.groupHeaderHeight:50,
+              scrollToColumn: props.goToColumn,
+              isColumnResizing: false,
+              onColumnResizeEndCallback: props.onColumnResizeEndCallback
+            },
+
+            props.cols.map(function(col, index) {
+              var column;
+              var width = col.show ? (col.width ? col.width :
+                (columnWidths[col.name] ? columnWidths[col.name] : 200)) : 0;
+
+              if (props.groupHeader) {
+                column = React.createElement(ColumnGroup, {
+                    header:
+                      React.createElement(Filter, {type: props.filters[col.name].type, name: col.name,
+                        max: col.max, min: col.min, filter: props.filters[col.name],
+                        placeholder: "Filter column",
+                        onFilterKeywordChange: props.onFilterKeywordChange}
+                      ),
+
+                    key: col.name,
+                    fixed: col.fixed,
+                    align: "center"
                   },
+                  React.createElement(Column, {
+                    header:
+                      React.createElement(HeaderWrapper, {cellDataKey: col.name, columnData: {displayName:col.displayName,sortFlag:props.sortBy === col.name,
+                        sortDirArrow:props.sortDirArrow,filterAll:props.filterAll,type:props.filters[col.name].type},
+                        sortNSet: props.sortNSet, filter: props.filters[col.name],
+                        shortLabel: headerShortLabels[col.name]}
+                      ),
 
-                  props.cols.map(function(col, index) {
-                      var column;
-                      var width = col.show ? (col.width ? col.width :
-                        (columnWidths[col.name] ? columnWidths[col.name] : 200)) : 0;
-
-                      if (props.groupHeader) {
-                          column = React.createElement(ColumnGroup, {
-                                header:
-                                  React.createElement(Filter, {type: props.filters[col.name].type, name: col.name,
-                                      max: col.max, min: col.min, filter: props.filters[col.name],
-                                      placeholder: "Filter column",
-                                      onFilterKeywordChange: props.onFilterKeywordChange}
-                                  ),
-
-                                key: col.name,
-                                fixed: col.fixed,
-                                align: "center"
-                            },
-                            React.createElement(Column, {
-                                header:
-                                  React.createElement(HeaderWrapper, {cellDataKey: col.name, columnData: {displayName:col.displayName,sortFlag:props.sortBy === col.name,
-                                      sortDirArrow:props.sortDirArrow,filterAll:props.filterAll,type:props.filters[col.name].type},
-                                      sortNSet: props.sortNSet, filter: props.filters[col.name],
-                                      shortLabel: headerShortLabels[col.name]}
-                                  ),
-
-                                cell: React.createElement(CustomizeCell, {data: rows, field: col.name,
-                                    filterAll: props.filterAll, shortLabels: cellShortLabels,
-                                    tableType: props.tableType,
-                                    selectRow: self.selectRow,
-                                    selectGene: self.selectGene,
-                                    selectedRowIndex: selectedRowIndex,
-                                    selectedGeneRowIndex: selectedGeneRowIndex,
-                                    pieLabelMouseEnterFunc: props.pieLabelMouseEnterFunc,
-                                    pieLabelMouseLeaveFunc: props.pieLabelMouseLeaveFunc}
-                                ),
-                                width: width,
-                                fixed: col.fixed,
-                                allowCellsRecycling: true,
-                                flexGrow: props.cols.length - index - 1}
-                            )
-                          )
-                      } else {
-                          column = React.createElement(Column, {
-                              header:
-                                React.createElement(HeaderWrapper, {cellDataKey: col.name, columnData: {displayName:col.displayName,sortFlag:props.sortBy === col.name,
-                                    sortDirArrow:props.sortDirArrow,filterAll:props.filterAll,type:props.filters[col.name].type},
-                                    sortNSet: props.sortNSet, filter: props.filters[col.name],
-                                    shortLabel: headerShortLabels[col.name]}
-                                ),
-
-                              cell: React.createElement(CustomizeCell, {data: rows, field: col.name,
-                                  filterAll: props.filterAll,
-                                  shortLabels: cellShortLabels,
-                                  tableType: props.tableType,
-                                  selectRow: self.selectRow,
-                                  selectGene: self.selectGene,
-                                  selectedRowIndex: selectedRowIndex,
-                                  selectedGeneRowIndex: selectedGeneRowIndex,
-                                  pieLabelMouseEnterFunc: props.pieLabelMouseEnterFunc,
-                                  pieLabelMouseLeaveFunc: props.pieLabelMouseLeaveFunc}
-                              ),
-                              width: width,
-                              fixed: col.fixed,
-                              allowCellsRecycling: true,
-                              key: col.name}
-                          )
-                      }
-                      return (
-                        column
-                      );
-                  })
-
+                    cell: React.createElement(CustomizeCell, {data: rows, field: col.name,
+                      filterAll: props.filterAll, shortLabels: cellShortLabels,
+                      tableType: props.tableType,
+                      selectRow: self.selectRow,
+                      selectGene: self.selectGene,
+                      selectedRowIndex: selectedRowIndex,
+                      selectedGeneRowIndex: selectedGeneRowIndex,
+                      pieLabelMouseEnterFunc: props.pieLabelMouseEnterFunc,
+                      pieLabelMouseLeaveFunc: props.pieLabelMouseLeaveFunc}
+                    ),
+                    width: width,
+                    fixed: col.fixed,
+                    allowCellsRecycling: true,
+                    isResizable: props.isResizable,
+                    columnKey: col.name,
+                    key: col.name}
+                  )
                 )
-              )
-            );
-        }
-    });
+              } else {
+                column = React.createElement(Column, {
+                  header:
+                    React.createElement(HeaderWrapper, {cellDataKey: col.name, columnData: {displayName:col.displayName,sortFlag:props.sortBy === col.name,
+                      sortDirArrow:props.sortDirArrow,filterAll:props.filterAll,type:props.filters[col.name].type},
+                      sortNSet: props.sortNSet, filter: props.filters[col.name],
+                      shortLabel: headerShortLabels[col.name]}
+                    ),
+
+                  cell: React.createElement(CustomizeCell, {data: rows, field: col.name,
+                    filterAll: props.filterAll,
+                    shortLabels: cellShortLabels,
+                    tableType: props.tableType,
+                    selectRow: self.selectRow,
+                    selectGene: self.selectGene,
+                    selectedRowIndex: selectedRowIndex,
+                    selectedGeneRowIndex: selectedGeneRowIndex,
+                    confirmedRowsIndex: confirmedRowsIndex,
+                    pieLabelMouseEnterFunc: props.pieLabelMouseEnterFunc,
+                    pieLabelMouseLeaveFunc: props.pieLabelMouseLeaveFunc}
+                  ),
+                  width: width,
+                  fixed: col.fixed,
+                  allowCellsRecycling: true,
+                  columnKey: col.name,
+                  key: col.name,
+                  isResizable: props.isResizable}
+                )
+              }
+              return (
+                column
+              );
+            })
+
+          )
+        )
+      );
+    }
+  });
 
 // Root component
-    var Main = React.createClass({displayName: "Main",
-        SortTypes: {
-            ASC: 'ASC',
-            DESC: 'DESC'
-        },
+  var Main = React.createClass({displayName: "Main",
+    SortTypes: {
+      ASC: 'ASC',
+      DESC: 'DESC'
+    },
 
-        rows: null,
+    rows: null,
 
-        getColumnWidth: function(cols, rows, measureMethod, columnMinWidth) {
-            var columnWidth = {};
-            var self = this;
-            if (self.props.autoColumnWidth) {
-                var rulerWidth = 0;
-                _.each(rows, function(row) {
-                    _.each(row, function(data, attr) {
-                        if (data) {
-                            data = data.toString();
-                            if (!columnWidth.hasOwnProperty(attr)) {
-                                columnWidth[attr] = 0;
-                            }
-                            switch (measureMethod) {
-                                case 'jquery':
-                                    var ruler = $("#ruler");
-                                    ruler.css('font-size', '14px');
-                                    ruler.text(data);
-                                    rulerWidth = ruler.outerWidth();
-                                    break;
-                                default:
-                                    var upperCaseLength = data.replace(/[^A-Z]/g, "").length;
-                                    var dataLength = data.length;
-                                    rulerWidth = upperCaseLength * 10 +  (dataLength - upperCaseLength) * 8 + 15;
-                                    break;
-                            }
+    getColumnWidth: function(cols, rows, measureMethod, columnMinWidth) {
+      var columnWidth = {};
+      var self = this;
+      if (self.props.autoColumnWidth) {
+        var rulerWidth = 0;
+        _.each(rows, function(row) {
+          _.each(row, function(data, attr) {
+            if (data) {
+              data = data.toString();
+              if (!columnWidth.hasOwnProperty(attr)) {
+                columnWidth[attr] = 0;
+              }
+              switch (measureMethod) {
+                case 'jquery':
+                  var ruler = $("#ruler");
+                  ruler.css('font-size', '14px');
+                  ruler.text(data);
+                  rulerWidth = ruler.outerWidth();
+                  break;
+                default:
+                  var upperCaseLength = data.replace(/[^A-Z]/g, "").length;
+                  var dataLength = data.length;
+                  rulerWidth = upperCaseLength * 10 + (dataLength - upperCaseLength) * 8 + 15;
+                  break;
+              }
 
-                            columnWidth[attr] = columnWidth[attr] < rulerWidth ? rulerWidth : columnWidth[attr];
-                        }
-                    });
-                });
+              columnWidth[attr] = columnWidth[attr] < rulerWidth ? rulerWidth : columnWidth[attr];
+            }
+          });
+        });
 
-                //20px is the padding.
-                columnWidth = _.object(_.map(columnWidth, function(length, attr) {
-                    return [attr, length > self.props.columnMaxWidth ?
-                      self.props.columnMaxWidth :
-                      ( (length + 20) < columnMinWidth ?
-                        columnMinWidth : (length + 20))];
-                }));
+        //20px is the padding.
+        columnWidth = _.object(_.map(columnWidth, function(length, attr) {
+          return [attr, length > self.props.columnMaxWidth ?
+            self.props.columnMaxWidth :
+            ( (length + 20) < columnMinWidth ?
+              columnMinWidth : (length + 20))];
+        }));
+      } else {
+        _.each(cols, function(col, attr) {
+          columnWidth[col.name] = col.width ? col.width : 200;
+        });
+      }
+      return columnWidth;
+    },
+
+    getShortLabels: function(rows, cols, columnWidth, measureMethod) {
+      var cellShortLabels = [];
+      var headerShortLabels = {};
+
+      _.each(rows, function(row) {
+        var rowWidthObj = {};
+        _.each(row, function(content, attr) {
+          var _label = content;
+          var _labelShort = _label;
+          var _labelWidth;
+          if (_label) {
+            _label = _label.toString();
+            switch (measureMethod) {
+              case 'jquery':
+                var ruler = $('#ruler');
+                ruler.text(_label);
+                ruler.css('font-size', '14px');
+                _labelWidth = ruler.outerWidth();
+                break;
+              default:
+                var upperCaseLength = _label.replace(/[^A-Z]/g, "").length;
+                var dataLength = _label.length;
+                _labelWidth = upperCaseLength * 10 + (dataLength - upperCaseLength) * 8 + 15;
+                break;
+            }
+            if (_labelWidth > columnWidth[attr]) {
+              var end = Math.floor(_label.length * columnWidth[attr] / _labelWidth) - 3;
+              _labelShort = _label.substring(0, end) + '...';
             } else {
-                _.each(cols, function(col, attr) {
-                    columnWidth[col.name] = col.width ? col.width : 200;
-                });
+              _labelShort = _label;
             }
-            return columnWidth;
-        },
+          }
+          rowWidthObj[attr] = _labelShort;
+        });
+        cellShortLabels.push(rowWidthObj);
+      });
 
-        getShortLabels: function(rows, cols, columnWidth, measureMethod) {
-            var cellShortLabels = [];
-            var headerShortLabels = {};
+      _.each(cols, function(col) {
+        if (!col.hasOwnProperty('show') || col.show) {
+          var _label = col.displayName;
+          var _shortLabel = '';
+          var _labelWidth = _label.toString().length * 8 + 20;
 
-            _.each(rows, function(row) {
-                var rowWidthObj = {};
-                _.each(row, function(content, attr) {
-                    var _label = content;
-                    var _labelShort = _label;
-                    var _labelWidth;
-                    if (_label) {
-                        _label = _label.toString();
-                        switch (measureMethod) {
-                            case 'jquery':
-                                var ruler = $('#ruler');
-                                ruler.text(_label);
-                                ruler.css('font-size', '14px');
-                                _labelWidth = ruler.outerWidth();
-                                break;
-                            default:
-                                var upperCaseLength = _label.replace(/[^A-Z]/g, "").length;
-                                var dataLength = _label.length;
-                                _labelWidth = upperCaseLength * 10 +  (dataLength - upperCaseLength) * 8 + 15;
-                                break;
-                        }
-                        if (_labelWidth > columnWidth[attr]) {
-                            var end = Math.floor(_label.length * columnWidth[attr] / _labelWidth) - 3;
-                            _labelShort = _label.substring(0, end) + '...';
-                        } else {
-                            _labelShort = _label;
-                        }
-                    }
-                    rowWidthObj[attr] = _labelShort;
-                });
-                cellShortLabels.push(rowWidthObj);
-            });
-
-            _.each(cols, function(col) {
-                var _label = col.displayName;
-                var _shortLabel = '';
-                var _labelWidth = _label.toString().length * 8 + 20;
-
-                if (_label) {
-                    _label = _label.toString();
-                    switch (measureMethod) {
-                        case 'jquery':
-                            var ruler = $('#ruler');
-                            ruler.text(_label);
-                            ruler.css('font-size', '14px');
-                            ruler.css('font-weight', 'bold');
-                            _labelWidth = ruler.outerWidth() + 20;
-                            break;
-                        default:
-                            var upperCaseLength = _label.replace(/[^A-Z]/g, "").length;
-                            var dataLength = _label.length;
-                            _labelWidth = upperCaseLength * 10 +  (dataLength - upperCaseLength) * 8 + 20;
-                            break;
-                    }
-                    if (_labelWidth > columnWidth[col.name]) {
-                        var end = Math.floor(_label.length * columnWidth[col.name] / _labelWidth) - 3;
-                        _shortLabel = _label.substring(0, end) + '...';
-                    } else {
-                        _shortLabel = _label;
-                    }
-                }
-                headerShortLabels[col.name] = _shortLabel;
-            });
-
-            return {
-                cell: cellShortLabels,
-                header: headerShortLabels
-            };
-        },
-        // Filters rows by selected column
-        filterRowsBy: function(filterAll, filters) {
-            var rows = this.rows.slice();
-            var filterRowsStartIndex = [];
-            var filteredRows = _.filter(rows, function(row, index) {
-                var allFlag = false; // Current row contains the global keyword
-                for (var col in filters) {
-                    if (!filters[col].hide) {
-                        if (filters[col].type == "STRING") {
-                            if (!row[col]) {
-                                if (filters[col].key.length > 0) {
-                                    return false;
-                                }
-                            } else {
-                                if (row[col].toLowerCase().indexOf(filters[col].key.toLowerCase()) < 0) {
-                                    return false;
-                                }
-                                if (row[col].toLowerCase().indexOf(filterAll.toLowerCase()) >= 0) {
-                                    allFlag = true;
-                                }
-                            }
-                        } else if (filters[col].type === "NUMBER" || filters[col].type == 'PERCENTAGE') {
-                            var cell = _.isUndefined(row[col]) ? row[col] : Number(row[col].toString().replace('%', ''));
-                            if (!isNaN(cell)) {
-                                if (Number(cell) < filters[col].min) {
-                                    return false;
-                                }
-                                if (Number(cell) > filters[col].max) {
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                }
-                if (allFlag) {
-                    filterRowsStartIndex.push(index);
-                }
-                return allFlag;
-            });
-
-            filteredRows = filteredRows.map(function(item, index) {
-                return {
-                    row: item,
-                    index: filterRowsStartIndex[index]
-                }
-            });
-            return filteredRows;
-        },
-
-        // Sorts rows by selected column
-        sortRowsBy: function(filters, filteredRows, sortBy, switchDir) {
-            var type = filters[sortBy].type, sortDir = this.state.sortDir,
-              SortTypes = this.SortTypes;
-            if (switchDir) {
-                if (sortBy === this.state.sortBy) {
-                    sortDir = this.state.sortDir === SortTypes.ASC ? SortTypes.DESC : SortTypes.ASC;
-                } else {
-                    sortDir = SortTypes.DESC;
-                }
+          if (_label) {
+            _label = _label.toString();
+            switch (measureMethod) {
+              case 'jquery':
+                var ruler = $('#ruler');
+                ruler.text(_label);
+                ruler.css('font-size', '14px');
+                ruler.css('font-weight', 'bold');
+                _labelWidth = ruler.outerWidth() + 20;
+                break;
+              default:
+                var upperCaseLength = _label.replace(/[^A-Z]/g, "").length;
+                var dataLength = _label.length;
+                _labelWidth = upperCaseLength * 10 + (dataLength - upperCaseLength) * 8 + 20;
+                break;
             }
-
-            filteredRows.sort(function(a, b) {
-                var sortVal = 0, aVal = a.row[sortBy], bVal = b.row[sortBy];
-
-
-                if (sortBy === 'cytoband' && window.hasOwnProperty('StudyViewUtil')) {
-                    var _sortResult = window.StudyViewUtil.cytobanBaseSort(aVal, bVal);
-                    sortVal = sortDir === SortTypes.ASC ? -_sortResult : _sortResult;
-                } else {
-
-                    if (type == "NUMBER") {
-                        aVal = (aVal && !isNaN(aVal)) ? Number(aVal) : aVal;
-                        bVal = (bVal && !isNaN(bVal)) ? Number(bVal) : bVal;
-                    }
-                    if (type == 'PERCENTAGE') {
-                        aVal = aVal ? Number(aVal.replace('%', '')) : aVal;
-                        bVal = bVal ? Number(bVal.replace('%', '')) : bVal;
-                    }
-                    if (typeof aVal != "undefined" && !isNaN(aVal) && typeof bVal != "undefined" && !isNaN(bVal)) {
-                        if (aVal > bVal) {
-                            sortVal = 1;
-                        }
-                        if (aVal < bVal) {
-                            sortVal = -1;
-                        }
-
-                        if (sortDir === SortTypes.ASC) {
-                            sortVal = sortVal * -1;
-                        }
-                    } else if (typeof aVal != "undefined" && typeof bVal != "undefined") {
-                        if (!isNaN(aVal)) {
-                            sortVal = -1;
-                        } else if (!isNaN(bVal)) {
-                            sortVal = 1;
-                        }
-                        else {
-                            if (aVal > bVal) {
-                                sortVal = 1;
-                            }
-                            if (aVal < bVal) {
-                                sortVal = -1;
-                            }
-
-                            if (sortDir === SortTypes.ASC) {
-                                sortVal = sortVal * -1;
-                            }
-                        }
-                    } else if (aVal) {
-                        sortVal = -1;
-                    }
-                    else {
-                        sortVal = 1;
-                    }
-                }
-                return -sortVal;
-            });
-
-            return {filteredRows: filteredRows, sortDir: sortDir};
-        },
-
-        // Sorts and sets state
-        sortNSet: function(sortBy) {
-            var result = this.sortRowsBy(this.state.filters, this.state.filteredRows, sortBy, true);
-            this.setState({
-                filteredRows: result.filteredRows,
-                sortBy: sortBy,
-                sortDir: result.sortDir
-            });
-        },
-
-        // Filters, sorts and sets state
-        filterSortNSet: function(filterAll, filters, sortBy) {
-            var filteredRows = this.filterRowsBy(filterAll, filters);
-            var result = this.sortRowsBy(filters, filteredRows, sortBy, false);
-            this.setState({
-                filteredRows: result.filteredRows,
-                sortBy: sortBy,
-                sortDir: result.sortDir,
-                filterAll: filterAll,
-                filters: filters
-            });
-        },
-
-        // Operations when filter keyword changes
-        onFilterKeywordChange: function(e) {
-            ++this.state.filterTimer;
-            e.persist();
-            var self = this;
-            var id = setTimeout(function() {
-                var filterAll = self.state.filterAll, filters = self.state.filters;
-                if (e.target.getAttribute("data-column") == "all") {
-                    filterAll = e.target.value;
-                } else {
-                    filters[e.target.getAttribute("data-column")].key = e.target.value;
-                }
-                self.filterSortNSet(filterAll, filters, self.state.sortBy);
-                --self.state.filterTimer;
-            }, 500);
-
-            if (this.state.filterTimer > 1) {
-                clearTimeout(id);
-                --self.state.filterTimer;
+            if (_labelWidth > columnWidth[col.name]) {
+              var end = Math.floor(_label.length * columnWidth[col.name] / _labelWidth) - 3;
+              _shortLabel = _label.substring(0, end) + '...';
+            } else {
+              _shortLabel = _label;
             }
-        },
-
-        // Operations when filter range changes
-        onFilterRangeChange: function(column, min, max) {
-            ++this.state.filterTimer;
-
-            var self = this;
-            var id = setTimeout(function() {
-                var filters = self.state.filters;
-                filters[column].min = min;
-                filters[column].max = max;
-                self.filterSortNSet(self.state.filterAll, filters, self.state.sortBy);
-                --self.state.filterTimer;
-            }, 500);
-
-            if (this.state.filterTimer > 1) {
-                clearTimeout(id);
-                --self.state.filterTimer;
-            }
-        },
-
-        // Operations when reset all filters
-        onResetFilters: function() {
-            var filters = this.state.filters;
-            _.each(filters, function(filter) {
-                if (!_.isUndefined(filter._key)) {
-                    filter.key = filter._key;
-                }
-                if (!_.isUndefined(filter._min)) {
-                    filter.min = filter._min;
-                }
-                if (!_.isUndefined(filter._max)) {
-                    filter.max = filter._max;
-                }
-                filter.reset = true;
-            });
-            this.filterSortNSet('', filters, this.state.sortBy);
-        },
-
-        updateCols: function(cols, filters) {
-            var filteredRows = this.filterRowsBy(this.state.filterAll, filters);
-            var result = this.sortRowsBy(filters, filteredRows, this.state.sortBy, false);
-            this.setState({
-                cols: cols,
-                filteredRows: result.filteredRows,
-                filters: filters
-            });
-        },
-
-        updateGoToColumn: function(val) {
-            this.setState({
-                goToColumn: val
-            });
-        },
-
-        // Processes input data, and initializes table states
-        getInitialState: function() {
-            var state = this.parseInputData(this.props.input, this.props.uniqueId,
-              this.props.selectedRow, this.props.groupHeader, this.props.columnSorting);
-
-            state.filteredRows = null;
-            state.filterAll = "";
-            state.sortBy = 'samples';
-            state.goToColumn = null;
-            state.filterTimer = 0;
-            state.sortDir = this.SortTypes.DESC;
-            return state;
-        },
-
-        getSelectedRowIndex: function(selectedRow) {
-            var selectedRowIndex = [];
-            _.each(this.rows, function(row, index) {
-                if (selectedRow.indexOf(row.uniqueId) !== -1) {
-                    selectedRowIndex.push(index);
-                }
-            })
-            return selectedRowIndex;
-        },
-
-        getSelectedGeneRowIndex: function(selectedGene) {
-            var selectedGeneRowIndex = [];
-            _.each(this.rows, function(row, index) {
-                if (selectedGene.indexOf(row.gene) !== -1) {
-                    selectedGeneRowIndex.push(index);
-                }
-            })
-            return selectedGeneRowIndex;
-        },
-
-        // Initializes filteredRows before first rendering
-        componentWillMount: function() {
-            this.filterSortNSet(this.state.filterAll, this.state.filters, this.state.sortBy);
-        },
-
-        // Activates range sliders after first rendering
-        componentDidMount: function() {
-            var onFilterRangeChange = this.onFilterRangeChange;
-            $('.rangeSlider')
-              .each(function() {
-                  var min = Math.floor(Number($(this).attr('data-min')) * 100) / 100, max = Math.round(Number($(this).attr('data-max')) * 100) / 100,
-                    column = $(this).attr('data-column'), diff = max - min, step = 1;
-                  var type = $(this).attr('data-type');
-
-                  if (diff < 0.01) {
-                      step = 0.001;
-                  } else if (diff < 0.1) {
-                      step = 0.01;
-                  } else if (diff < 2) {
-                      step = 0.1;
-                  }
-
-                  $(this).slider({
-                      range: true,
-                      min: min,
-                      max: max,
-                      step: step,
-                      values: [min, max],
-                      change: function(event, ui) {
-                          $("#range-" + column).text(ui.values[0] + " to " + ui.values[1]);
-                          onFilterRangeChange(column, ui.values[0], ui.values[1]);
-                      }
-                  });
-                  if (type === 'PERCENTAGE') {
-                      $("#range-" + column).text(min + "% to " + max + '%');
-                  } else {
-                      $("#range-" + column).text(min + " to " + max);
-                  }
-              });
-        },
-
-        // Sets default properties
-        getDefaultProps: function() {
-            return {
-                filter: "NONE",
-                download: "NONE",
-                showHide: false,
-                hideFilter: true,
-                scroller: false,
-                resultInfo: true,
-                groupHeader: true,
-                downloadFileName: 'data.txt',
-                autoColumnWidth: true,
-                columnMaxWidth: 300,
-                columnSorting: true,
-                tableType: 'mutatedGene',
-                selectedRow: [],
-                selectedGene: []
-            };
-        },
-
-        parseInputData: function(input, uniqueId, selectedRow, groupHeader, columnSorting) {
-            var cols = [], rows = [], rowsDict = {}, attributes = input.attributes,
-              data = input.data, dataLength = data.length, col, cell, i, filters = {},
-              uniqueId = uniqueId || 'id', newCol,
-              selectedRow = selectedRow || [],
-              measureMethod = (dataLength > 100000 || !this.props.autoColumnWidth) ? 'charNum' : 'jquery',
-              columnMinWidth = groupHeader ? 130 : 50; //The minimum width to at least fit in number slider.
-            var selectedRowIndex = [];
-
-            // Gets column info from input
-            var colsDict = {};
-            for (i = 0; i < attributes.length; i++) {
-                col = attributes[i];
-                newCol = {
-                    displayName: col.display_name,
-                    name: col.attr_id,
-                    type: col.datatype,
-                    fixed: false,
-                    show: true
-                };
-
-                if (col.hasOwnProperty('column_width')) {
-                    newCol.width = col.column_width;
-                }
-
-                if (_.isBoolean(col.show)) {
-                    newCol.show = col.show;
-                }
-
-                if (_.isBoolean(col.fixed)) {
-                    newCol.fixed = col.fixed;
-                }
-
-                cols.push(newCol);
-                colsDict[col.attr_id] = i;
-            }
-
-            // Gets data rows from input
-            for (i = 0; i < dataLength; i++) {
-                cell = data[i];
-                if (!rowsDict[cell[uniqueId]]) {
-                    rowsDict[cell[uniqueId]] = {};
-                }
-                rowsDict[cell[uniqueId]][cell.attr_id] = cell.attr_val;
-            }
-
-            var index = 0;
-            _.each(rowsDict, function(item, i) {
-                rowsDict[i][uniqueId] = i;
-                rows.push(rowsDict[i]);
-                if (selectedRow.indexOf(i) !== -1) {
-                    selectedRowIndex.push(index);
-                }
-                ++index;
-            });
-
-            // Gets the range of number type features
-            for (i = 0; i < cols.length; i++) {
-                col = cols[i];
-                var _filter = {
-                    type: col.type,
-                    hide: !col.show
-                };
-
-                if (col.type == "NUMBER" || col.type == "PERCENTAGE") {
-                    var min = Number.MAX_VALUE, max = -Number.MAX_VALUE;
-                    for (var j = 0; j < rows.length; j++) {
-                        cell = _.isUndefined(rows[j][col.name]) ? rows[j][col.name] : rows[j][col.name].toString().replace('%');
-                        if (typeof cell != "undefined" && !isNaN(cell)) {
-                            cell = Number(cell);
-                            max = cell > max ? cell : max;
-                            min = cell < min ? cell : min;
-                        }
-                    }
-                    if (max === -Number.MAX_VALUE || min === Number.MIN_VALUE) {
-                        _filter.key = '';
-                        _filter._key = '';
-                    } else {
-                        col.max = max;
-                        col.min = min;
-                        _filter.min = min;
-                        _filter.max = max;
-                        _filter._min = min;
-                        _filter._max = max;
-                    }
-                } else {
-                    _filter.key = '';
-                    _filter._key = '';
-                }
-                filters[col.name] = _filter;
-            }
-
-            if (columnSorting) {
-                cols = _.sortBy(cols, function(obj) {
-                    if (!_.isUndefined(obj.displayName)) {
-                        return obj.displayName;
-                    } else {
-                        return obj.name;
-                    }
-                });
-            }
-            this.rows = rows;
-
-            var columnWidths = this.getColumnWidth(cols, rows, measureMethod, columnMinWidth);
-            var shortLabels = this.getShortLabels(rows, cols, columnWidths, measureMethod);
-
-            return {
-                cols: cols,
-                rowsSize: rows.length,
-                filters: filters,
-                shortLabels: shortLabels,
-                columnWidths: columnWidths,
-                columnMinWidth: columnMinWidth,
-                selectedRowIndex: selectedRowIndex,
-                dataSize: dataLength
-            };
-        },
-        // If properties changed
-        componentWillReceiveProps: function(newProps) {
-            var state = this.parseInputData(newProps.input, newProps.uniqueId,
-              newProps.selectedRow, newProps.groupHeader, newProps.columnSorting);
-            state.filteredRows = null;
-            state.filterAll = "";
-            state.sortBy = 'samples';
-            state.goToColumn = null;
-            state.filterTimer = 0;
-
-            var filteredRows = this.filterRowsBy(state.filterAll, state.filters);
-            var result = this.sortRowsBy(state.filters, filteredRows, state.sortBy, false);
-
-            state.filteredRows = result.filteredRows;
-            state.sortDir = result.sortDir;
-
-            this.setState(state);
-        },
-
-        render: function() {
-            var sortDirArrow = this.state.sortDir === this.SortTypes.DESC ? 'fa fa-sort-desc' : 'fa fa-sort-asc';
-            var selectedGeneRowIndex = this.getSelectedGeneRowIndex(this.props.selectedGene);
-            var selectedRowIndex = this.getSelectedRowIndex(this.props.selectedRow);
-
-            return (
-              React.createElement("div", {className: "EFDT-table"},
-                React.createElement("div", {className: "EFDT-table-prefix"},
-                  React.createElement(TablePrefix, {cols: this.state.cols, rows: this.rows,
-                      onFilterKeywordChange: this.onFilterKeywordChange,
-                      onResetFilters: this.onResetFilters,
-                      filters: this.state.filters,
-                      updateCols: this.updateCols,
-                      updateGoToColumn: this.updateGoToColumn,
-                      scroller: this.props.scroller,
-                      filter: this.props.filter,
-                      hideFilter: this.props.hideFilter,
-                      getData: this.props.download,
-                      downloadFileName: this.props.downloadFileName,
-                      hider: this.props.showHide,
-                      fixedChoose: this.props.fixedChoose,
-                      resultInfo: this.props.resultInfo,
-                      rowsSize: this.state.rowsSize,
-                      filteredRowsSize: this.state.filteredRows.length}
-                  )
-                ),
-                React.createElement("div", {className: "EFDT-tableMain"},
-                  React.createElement(TableMainPart, {cols: this.state.cols,
-                      rows: this.rows,
-                      filteredRows: this.state.filteredRows,
-                      filters: this.state.filters,
-                      sortNSet: this.sortNSet,
-                      onFilterKeywordChange: this.onFilterKeywordChange,
-                      goToColumn: this.state.goToColumn,
-                      sortBy: this.state.sortBy,
-                      sortDirArrow: sortDirArrow,
-                      filterAll: this.state.filterAll,
-                      filter: this.props.filter,
-                      rowHeight: this.props.rowHeight,
-                      tableWidth: this.props.tableWidth,
-                      maxHeight: this.props.maxHeight,
-                      headerHeight: this.props.headerHeight,
-                      groupHeaderHeight: this.props.groupHeaderHeight,
-                      groupHeader: this.props.groupHeader,
-                      tableType: this.props.tableType,
-                      shortLabels: this.state.shortLabels,
-                      columnWidths: this.state.columnWidths,
-                      rowClickFunc: this.props.rowClickFunc,
-                      geneClickFunc: this.props.geneClickFunc,
-                      pieLabelMouseEnterFunc: this.props.pieLabelMouseEnterFunc,
-                      pieLabelMouseLeaveFunc: this.props.pieLabelMouseLeaveFunc,
-                      selectedRowIndex: selectedRowIndex,
-                      selectedGeneRowIndex: selectedGeneRowIndex}
-                  )
-                ),
-                React.createElement("div", {className: "EFDT-filter"},
-
-                  (this.props.filter === "ALL" || this.props.filter === "GLOBAL") ?
-                    React.createElement(Filter, {type: "STRING", name: "all",
-                        onFilterKeywordChange: this.onFilterKeywordChange}) :
-                    React.createElement("div", null)
-
-                )
-              )
-            );
+          }
+          headerShortLabels[col.name] = _shortLabel;
         }
-    });
+      });
 
-    return Main;
+      return {
+        cell: cellShortLabels,
+        header: headerShortLabels
+      };
+    },
+    // Filters rows by selected column
+    filterRowsBy: function(filterAll, filters) {
+      var rows = this.rows.slice();
+      var hasGroupHeader = this.props.groupHeader;
+      var filterRowsStartIndex = [];
+      var filteredRows = _.filter(rows, function(row, index) {
+        var allFlag = false; // Current row contains the global keyword
+        for (var col in filters) {
+          if (!filters[col].hide) {
+            if (filters[col].type == "STRING") {
+              if (!row[col] && hasGroupHeader) {
+                if (filters[col].key.length > 0) {
+                  return false;
+                }
+              } else {
+                if (hasGroupHeader && row[col].toLowerCase().indexOf(filters[col].key.toLowerCase()) < 0) {
+                  return false;
+                }
+                if (row[col] && row[col].toLowerCase().indexOf(filterAll.toLowerCase()) >= 0) {
+                  allFlag = true;
+                }
+              }
+            } else if (filters[col].type === "NUMBER" || filters[col].type == 'PERCENTAGE') {
+              var cell = _.isUndefined(row[col]) ? row[col] : Number(row[col].toString().replace('%', ''));
+              if (!isNaN(cell)) {
+                if (hasGroupHeader) {
+                  if (filters[col].min !== filters[col]._min && Number(cell) < filters[col].min) {
+                    return false;
+                  }
+                  if (filters[col].max !== filters[col]._max && Number(cell) > filters[col].max) {
+                    return false;
+                  }
+                }
+                if (row[col] && row[col].toString().toLowerCase().indexOf(filterAll.toLowerCase()) >= 0) {
+                  allFlag = true;
+                }
+              }
+            }
+          }
+        }
+        if (allFlag) {
+          filterRowsStartIndex.push(index);
+        }
+        return allFlag;
+      });
+
+      filteredRows = filteredRows.map(function(item, index) {
+        return {
+          row: item,
+          index: filterRowsStartIndex[index]
+        }
+      });
+      return filteredRows;
+    },
+
+    // Sorts rows by selected column
+    sortRowsBy: function(filters, filteredRows, sortBy, switchDir) {
+      var type = filters[sortBy].type, sortDir = this.state.sortDir,
+        SortTypes = this.SortTypes, confirmedRowsIndex = this.getSelectedRowIndex(this.state.confirmedRows);
+      if (switchDir) {
+        if (sortBy === this.state.sortBy) {
+          sortDir = this.state.sortDir === SortTypes.ASC ? SortTypes.DESC : SortTypes.ASC;
+        } else {
+          sortDir = SortTypes.DESC;
+        }
+      }
+
+      filteredRows.sort(function(a, b) {
+        var sortVal = 0, aVal = a.row[sortBy], bVal = b.row[sortBy];
+
+        if(confirmedRowsIndex.indexOf(a.index) !== -1 && confirmedRowsIndex.indexOf(b.index) === -1) {
+          return -1;
+        }
+
+        if(confirmedRowsIndex.indexOf(a.index) === -1 && confirmedRowsIndex.indexOf(b.index) !== -1) {
+          return 1;
+        }
+
+        if (sortBy === 'cytoband' && window.hasOwnProperty('StudyViewUtil')) {
+          var _sortResult = window.StudyViewUtil.cytobanBaseSort(aVal, bVal);
+          sortVal = sortDir === SortTypes.ASC ? -_sortResult : _sortResult;
+        } else {
+
+          if (type == "NUMBER") {
+            aVal = (aVal && !isNaN(aVal)) ? Number(aVal) : aVal;
+            bVal = (bVal && !isNaN(bVal)) ? Number(bVal) : bVal;
+          }
+          if (type == 'PERCENTAGE') {
+            aVal = aVal ? Number(aVal.replace('%', '')) : aVal;
+            bVal = bVal ? Number(bVal.replace('%', '')) : bVal;
+          }
+          if (typeof aVal != "undefined" && !isNaN(aVal) && typeof bVal != "undefined" && !isNaN(bVal)) {
+            if (aVal > bVal) {
+              sortVal = 1;
+            }
+            if (aVal < bVal) {
+              sortVal = -1;
+            }
+
+            if (sortDir === SortTypes.ASC) {
+              sortVal = sortVal * -1;
+            }
+          } else if (typeof aVal != "undefined" && typeof bVal != "undefined") {
+            if (!isNaN(aVal)) {
+              sortVal = -1;
+            } else if (!isNaN(bVal)) {
+              sortVal = 1;
+            }
+            else {
+              if (aVal > bVal) {
+                sortVal = 1;
+              }
+              if (aVal < bVal) {
+                sortVal = -1;
+              }
+
+              if (sortDir === SortTypes.ASC) {
+                sortVal = sortVal * -1;
+              }
+            }
+          } else if (aVal) {
+            sortVal = -1;
+          }
+          else {
+            sortVal = 1;
+          }
+        }
+        return -sortVal;
+      });
+
+      return {filteredRows: filteredRows, sortDir: sortDir};
+    },
+
+    // Sorts and sets state
+    sortNSet: function(sortBy) {
+      var result = this.sortRowsBy(this.state.filters, this.state.filteredRows, sortBy, true);
+      this.setState({
+        filteredRows: result.filteredRows,
+        sortBy: sortBy,
+        sortDir: result.sortDir
+      });
+    },
+
+    // Filters, sorts and sets state
+    filterSortNSet: function(filterAll, filters, sortBy) {
+      var filteredRows = this.filterRowsBy(filterAll, filters);
+      var result = this.sortRowsBy(filters, filteredRows, sortBy, false);
+      this.setState({
+        filteredRows: result.filteredRows,
+        sortBy: sortBy,
+        sortDir: result.sortDir,
+        filterAll: filterAll,
+        filters: filters
+      });
+    },
+
+    // Operations when filter keyword changes
+    onFilterKeywordChange: function(e) {
+      ++this.state.filterTimer;
+
+      //Disable event pooling in react, see https://goo.gl/1mq6qI
+      e.persist();
+
+      var self = this;
+      var id = setTimeout(function() {
+        var filterAll = self.state.filterAll, filters = self.state.filters;
+        if (e.target.getAttribute("data-column") == "all") {
+          filterAll = e.target.value;
+        } else {
+          filters[e.target.getAttribute("data-column")].key = e.target.value;
+        }
+        self.filterSortNSet(filterAll, filters, self.state.sortBy);
+        --self.state.filterTimer;
+      }, 500);
+
+      if (this.state.filterTimer > 1) {
+        clearTimeout(id);
+        --self.state.filterTimer;
+      }
+    },
+
+    // Operations when filter range changes
+    onFilterRangeChange: function(column, min, max) {
+      ++this.state.filterTimer;
+
+      var self = this;
+      var id = setTimeout(function() {
+        var filters = self.state.filters;
+        filters[column].min = min;
+        filters[column].max = max;
+        self.filterSortNSet(self.state.filterAll, filters, self.state.sortBy);
+        --self.state.filterTimer;
+      }, 500);
+
+      if (this.state.filterTimer > 1) {
+        clearTimeout(id);
+        --self.state.filterTimer;
+      }
+    },
+
+    // Operations when reset all filters
+    onResetFilters: function() {
+      var filters = this.state.filters;
+      _.each(filters, function(filter) {
+        if (!_.isUndefined(filter._key)) {
+          filter.key = filter._key;
+        }
+        if (!_.isUndefined(filter._min)) {
+          filter.min = filter._min;
+        }
+        if (!_.isUndefined(filter._max)) {
+          filter.max = filter._max;
+        }
+        filter.reset = true;
+      });
+      if (this.props.groupHeader) {
+        this.registerSliders();
+      }
+      this.filterSortNSet('', filters, this.state.sortBy);
+    },
+
+    updateCols: function(cols, filters) {
+      var filteredRows = this.filterRowsBy(this.state.filterAll, filters);
+      var result = this.sortRowsBy(filters, filteredRows, this.state.sortBy, false);
+      this.setState({
+        cols: cols,
+        filteredRows: result.filteredRows,
+        filters: filters
+      });
+      if (this.props.groupHeader) {
+        this.registerSliders();
+      }
+    },
+
+    updateGoToColumn: function(val) {
+      this.setState({
+        goToColumn: val
+      });
+    },
+
+    registerSliders: function() {
+      var onFilterRangeChange = this.onFilterRangeChange;
+      $('.rangeSlider')
+        .each(function() {
+          var min = Math.floor(Number($(this).attr('data-min')) * 100) / 100, max = (Math.ceil(Number($(this).attr('data-max')) * 100)) / 100,
+            column = $(this).attr('data-column'), diff = max - min, step = 1;
+          var type = $(this).attr('data-type');
+
+          if (diff < 0.01) {
+            step = 0.001;
+          } else if (diff < 0.1) {
+            step = 0.01;
+          } else if (diff < 2) {
+            step = 0.1;
+          }
+
+          $(this).slider({
+            range: true,
+            min: min,
+            max: max,
+            step: step,
+            values: [min, max],
+            change: function(event, ui) {
+              $("#range-" + column).text(ui.values[0] + " to " + ui.values[1]);
+              onFilterRangeChange(column, ui.values[0], ui.values[1]);
+            }
+          });
+          if (type === 'PERCENTAGE') {
+            $("#range-" + column).text(min + "% to " + max + '%');
+          } else {
+            $("#range-" + column).text(min + " to " + max);
+          }
+        });
+    },
+    // Processes input data, and initializes table states
+    getInitialState: function() {
+      var state = this.parseInputData(this.props.input, this.props.uniqueId,
+        this.props.selectedRows, this.props.groupHeader, this.props.columnSorting);
+
+      state.confirmedRows = ['mutatedGene', 'cna'].indexOf(this.props.tableType) !== -1 ? state.selectedRows : [];
+      state.filteredRows = null;
+      state.filterAll = "";
+      state.sortBy = this.props.sortBy || 'samples';
+      state.goToColumn = null;
+      state.filterTimer = 0;
+      state.sortDir = this.props.sortDir || this.SortTypes.DESC;
+      state.rowClickFunc = this.rowClickCallback;
+      state.selectButtonClickCallback = this.selectButtonClickCallback;
+      return state;
+    },
+
+    rowClickCallback: function(selectedRows, isSelected, allSelectedRows) {
+      var uniqueId = this.props.uniqueId;
+      this.setState({
+        selectedRows: allSelectedRows.map(function(item) {
+          return item[uniqueId];
+        })
+      });
+      if(_.isFunction(this.props.rowClickFunc)) {
+        this.props.rowClickFunc(selectedRows, isSelected, allSelectedRows);
+      }
+    },
+
+    selectButtonClickCallback: function() {
+      var selectedRows = this.state.selectedRows;
+      this.setState({
+        confirmedRows: selectedRows
+      });
+      if(_.isFunction(this.props.selectButtonClickCallback)) {
+        this.props.selectButtonClickCallback();
+      }
+    },
+
+    getSelectedRowIndex: function(selectedRows) {
+      var selectedRowIndex = [];
+      var uniqueId = this.props.uniqueId;
+      _.each(this.rows, function(row, index) {
+        if (selectedRows.indexOf(row[uniqueId]) !== -1) {
+          selectedRowIndex.push(index);
+        }
+      })
+      return selectedRowIndex;
+    },
+
+    getSelectedGeneRowIndex: function(selectedGene) {
+      var selectedGeneRowIndex = [];
+      _.each(this.rows, function(row, index) {
+        if (selectedGene.indexOf(row.gene) !== -1) {
+          selectedGeneRowIndex.push(index);
+        }
+      })
+      return selectedGeneRowIndex;
+    },
+
+    // Initializes filteredRows before first rendering
+    componentWillMount: function() {
+      this.filterSortNSet(this.state.filterAll, this.state.filters, this.state.sortBy);
+    },
+
+    parseInputData: function(input, uniqueId, selectedRows, groupHeader, columnSorting) {
+      var cols = [], rows = [], rowsDict = {}, attributes = input.attributes,
+        data = input.data, dataLength = data.length, col, cell, i, filters = {},
+        uniqueId = uniqueId || 'id', newCol,
+        selectedRows = selectedRows || [],
+        measureMethod = (dataLength > 100000 || !this.props.autoColumnWidth) ? 'charNum' : 'jquery',
+        columnMinWidth = groupHeader ? 130 : 50; //The minimum width to at least fit in number slider.
+      var selectedRowIndex = [];
+
+      // Gets column info from input
+      var colsDict = {};
+      for (i = 0; i < attributes.length; i++) {
+        col = attributes[i];
+        newCol = {
+          displayName: col.display_name,
+          name: col.attr_id,
+          type: col.datatype,
+          fixed: false,
+          show: true
+        };
+
+        if (col.hasOwnProperty('column_width')) {
+          newCol.width = col.column_width;
+        }
+
+        if (_.isBoolean(col.show)) {
+          newCol.show = col.show;
+        }
+
+        if (_.isBoolean(col.fixed)) {
+          newCol.fixed = col.fixed;
+        }
+
+        cols.push(newCol);
+        colsDict[col.attr_id] = i;
+      }
+
+      // Gets data rows from input
+      for (i = 0; i < dataLength; i++) {
+        cell = data[i];
+        if (!rowsDict[cell[uniqueId]]) {
+          rowsDict[cell[uniqueId]] = {};
+        }
+        rowsDict[cell[uniqueId]][cell.attr_id] = cell.attr_val;
+      }
+
+      var index = 0;
+      _.each(rowsDict, function(item, i) {
+        rowsDict[i][uniqueId] = i;
+        rows.push(rowsDict[i]);
+        if (selectedRows.indexOf(i) !== -1) {
+          selectedRowIndex.push(index);
+        }
+        ++index;
+      });
+
+      // Gets the range of number type features
+      for (i = 0; i < cols.length; i++) {
+        col = cols[i];
+        var _filter = {
+          type: col.type,
+          hide: !col.show
+        };
+
+        if (col.type == "NUMBER" || col.type == "PERCENTAGE") {
+          var min = Number.MAX_VALUE, max = -Number.MAX_VALUE;
+          for (var j = 0; j < rows.length; j++) {
+            cell = _.isUndefined(rows[j][col.name]) ? rows[j][col.name] : rows[j][col.name].toString().replace('%');
+            if (typeof cell != "undefined" && !isNaN(cell)) {
+              cell = Number(cell);
+              max = cell > max ? cell : max;
+              min = cell < min ? cell : min;
+            }
+          }
+          if (max === -Number.MAX_VALUE || min === Number.MIN_VALUE) {
+            _filter.key = '';
+            _filter._key = '';
+          } else {
+            col.max = max;
+            col.min = min;
+            _filter.min = min;
+            _filter.max = max;
+            _filter._min = min;
+            _filter._max = max;
+          }
+        } else {
+          _filter.key = '';
+          _filter._key = '';
+        }
+        filters[col.name] = _filter;
+      }
+
+      if (columnSorting) {
+        cols = _.sortBy(cols, function(obj) {
+          if (!_.isUndefined(obj.displayName)) {
+            return obj.displayName;
+          } else {
+            return obj.name;
+          }
+        });
+      }
+      this.rows = rows;
+
+      var columnWidths = this.getColumnWidth(cols, rows, measureMethod, columnMinWidth);
+      var shortLabels = this.getShortLabels(rows, cols, columnWidths, measureMethod);
+
+      return {
+        cols: cols,
+        rowsSize: rows.length,
+        filters: filters,
+        shortLabels: shortLabels,
+        columnWidths: columnWidths,
+        columnMinWidth: columnMinWidth,
+        selectedRowIndex: selectedRowIndex,
+        selectedRows: selectedRows,
+        dataSize: dataLength,
+        measureMethod: measureMethod
+      };
+    },
+    // If properties changed
+    componentWillReceiveProps: function(newProps) {
+      var state = this.parseInputData(newProps.input, newProps.uniqueId,
+        newProps.selectedRows, newProps.groupHeader, newProps.columnSorting);
+      state.confirmedRows = ['mutatedGene', 'cna'].indexOf(newProps.tableType) !== -1 ? state.selectedRows : [];
+      state.filteredRows = null;
+      state.filterAll = this.state.filterAll || '';
+      state.sortBy = this.props.sortBy || 'samples';
+      state.sortDir = this.props.sortDir || this.SortTypes.DESC;
+      state.goToColumn = null;
+      state.filterTimer = 0;
+
+      var filteredRows = this.filterRowsBy(state.filterAll, state.filters);
+      var result = this.sortRowsBy(state.filters, filteredRows, state.sortBy, false);
+      state.filteredRows = result.filteredRows;
+
+      this.setState(state);
+    },
+
+    //Will be triggered if the column width has been changed
+    onColumnResizeEndCallback: function(width, key) {
+      var foundMatch = false;
+      var cols = this.state.cols;
+
+      _.each(cols, function(col, attr) {
+        if (col.name === key) {
+          col.width = width;
+          foundMatch = true;
+        }
+      });
+      if (foundMatch) {
+        var columnWidths = this.state.columnWidths;
+        columnWidths[key] = width;
+        var shortLabels = this.getShortLabels(this.rows, cols, columnWidths, this.state.measureMethod);
+        this.setState({
+          columnWidths: columnWidths,
+          shortLabels: shortLabels,
+          cols: cols
+        });
+      }
+    },
+
+    // Activates range sliders after first rendering
+    componentDidMount: function() {
+      if (this.props.groupHeader) {
+        this.registerSliders();
+      }
+    },
+
+    // Sets default properties
+    getDefaultProps: function() {
+      return {
+        filter: "NONE",
+        download: "NONE",
+        showHide: false,
+        hideFilter: true,
+        scroller: false,
+        resultInfo: true,
+        groupHeader: true,
+        downloadFileName: 'data.txt',
+        autoColumnWidth: true,
+        columnMaxWidth: 300,
+        columnSorting: true,
+        tableType: 'mutatedGene',
+        selectedRows: [],
+        selectedGene: [],
+        sortBy: 'samples',
+        sortDir: 'DESC',
+        isResizable: false
+      };
+    },
+
+    render: function() {
+      var sortDirArrow = this.state.sortDir === this.SortTypes.DESC ? 'fa fa-sort-desc' : 'fa fa-sort-asc';
+      var selectedGeneRowIndex = this.getSelectedGeneRowIndex(this.props.selectedGene);
+      var selectedRowIndex = this.getSelectedRowIndex(this.state.selectedRows);
+      var confirmedRowsIndex = this.getSelectedRowIndex(this.state.confirmedRows);
+      return (
+        React.createElement("div", {className: "EFDT-table"},
+          React.createElement("div", {className: "EFDT-table-prefix"},
+            React.createElement(TablePrefix, {cols: this.state.cols, rows: this.rows,
+              onFilterKeywordChange: this.onFilterKeywordChange,
+              onResetFilters: this.onResetFilters,
+              filters: this.state.filters,
+              updateCols: this.updateCols,
+              updateGoToColumn: this.updateGoToColumn,
+              scroller: this.props.scroller,
+              filter: this.props.filter,
+              hideFilter: this.props.hideFilter,
+              getData: this.props.download,
+              downloadFileName: this.props.downloadFileName,
+              hider: this.props.showHide,
+              fixedChoose: this.props.fixedChoose,
+              resultInfo: this.props.resultInfo,
+              rowsSize: this.state.rowsSize,
+              filteredRowsSize: this.state.filteredRows.length}
+            )
+          ),
+          React.createElement("div", {className: "EFDT-tableMain"},
+            React.createElement(TableMainPart, {cols: this.state.cols,
+              rows: this.rows,
+              filteredRows: this.state.filteredRows,
+              filters: this.state.filters,
+              sortNSet: this.sortNSet,
+              onFilterKeywordChange: this.onFilterKeywordChange,
+              goToColumn: this.state.goToColumn,
+              sortBy: this.state.sortBy,
+              sortDirArrow: sortDirArrow,
+              filterAll: this.state.filterAll,
+              filter: this.props.filter,
+              rowHeight: this.props.rowHeight,
+              tableWidth: this.props.tableWidth,
+              maxHeight: this.props.maxHeight,
+              headerHeight: this.props.headerHeight,
+              groupHeaderHeight: this.props.groupHeaderHeight,
+              groupHeader: this.props.groupHeader,
+              tableType: this.props.tableType,
+              confirmedRowsIndex: confirmedRowsIndex,
+              shortLabels: this.state.shortLabels,
+              columnWidths: this.state.columnWidths,
+              rowClickFunc: this.state.rowClickFunc,
+              geneClickFunc: this.props.geneClickFunc,
+              selectButtonClickCallback: this.state.selectButtonClickCallback,
+              pieLabelMouseEnterFunc: this.props.pieLabelMouseEnterFunc,
+              pieLabelMouseLeaveFunc: this.props.pieLabelMouseLeaveFunc,
+              selectedRowIndex: selectedRowIndex,
+              selectedGeneRowIndex: selectedGeneRowIndex,
+              isResizable: this.props.isResizable,
+              onColumnResizeEndCallback: this.onColumnResizeEndCallback}
+            )
+          ),
+          React.createElement("div", {className: "EFDT-filter"},
+
+            (this.props.filter === "ALL" || this.props.filter === "GLOBAL") ?
+              React.createElement(Filter, {type: "STRING", name: "all",
+                onFilterKeywordChange: this.onFilterKeywordChange}) :
+              React.createElement("div", null)
+
+          ),
+          React.createElement("div", {className: "EFDT-finish-selection-button"},
+
+            (['mutatedGene', 'cna'].indexOf(this.props.tableType) !== -1 && this.state.selectedRows.length > 0) ?
+              React.createElement("button", {className: "btn btn-default btn-xs", onClick: this.state.selectButtonClickCallback}, "Select") : ''
+
+          )
+        )
+      );
+    }
+  });
+
+  return Main;
 })();

--- a/app/scripts/views/components/dataTable/MutatedGeneCNATable.js
+++ b/app/scripts/views/components/dataTable/MutatedGeneCNATable.js
@@ -1448,7 +1448,7 @@ var EnhancedFixedDataTableSpecial = (function() {
           ),
           React.createElement("div", {className: "EFDT-finish-selection-button"},
 
-            (['mutatedGene', 'cna'].indexOf(this.props.tableType) !== -1 && this.state.selectedRows.length > 0) ?
+            (['mutatedGene', 'cna'].indexOf(this.props.tableType) !== -1 && this.state.selectedRows.length > 0 && this.state.confirmedRows.length !== this.state.selectedRows.length ) ?
               React.createElement("button", {className: "btn btn-default btn-xs", onClick: this.state.selectButtonClickCallback}, "Select") : ''
 
           )

--- a/app/scripts/views/components/dataTable/tableView.js
+++ b/app/scripts/views/components/dataTable/tableView.js
@@ -47,7 +47,7 @@
     var selectedSamples = [];
     var allSamplesIds = [];
     var reactTableData = {};
-    var initialLoaded = false;
+    var initialized = false;
     var patientDataIndices = {};
     var selectedRowData = [];
 
@@ -64,22 +64,20 @@
 
 
     content.init =
-      function(_completeSamples, _selectedSamples, _selectedGenes, _indices, _geneData,
-               _data, _chartId, _type, _callbacks) {
-        _.each(_geneData, function(item, index) {
-          sequencedSampleIds = sequencedSampleIds.concat(item.caseIds);
-        });
-        sequencedSampleIds = _.uniq(sequencedSampleIds);
-        allSamplesIds = _completeSamples;
-        selectedSamples = _completeSamples;
+      function(_attributes, _selectedSamples, _selectedGenes, _indices,
+               _data, _chartId, _callbacks) {
+        initialized = false;
+        allSamplesIds = _attributes.options.allCases;
+        selectedSamples = _selectedSamples;
+        sequencedSampleIds = _attributes.options.sequencedCases;
         selectedGenes = _selectedGenes;
         chartId_ = _chartId;
         patientDataIndices = _indices;
         data_ = _data;
-        geneData_ = _geneData;
-        type_ = _type;
+        geneData_ = _attributes.gene_list;
+        type_ = _attributes.type;
         callbacks_ = _callbacks;
-        if (iViz.util.tableView.compare(_completeSamples, _selectedSamples)) {
+        if (iViz.util.tableView.compare(allSamplesIds, _selectedSamples)) {
           initReactTable(true);
         } else {
           content.update(_selectedSamples);
@@ -91,7 +89,8 @@
       var includeMutationCount = false;
       if (_selectedRows !== undefined)
         selectedRows = _selectedRows;
-      if (!iViz.util.tableView.compare(selectedSamples, _selectedSamples)) {
+      if ((!initialized) || (!iViz.util.tableView.compare(selectedSamples, _selectedSamples))) {
+        initialized = true;
         selectedSamples = _selectedSamples;
         if (!iViz.util.tableView.compare(allSamplesIds, _selectedSamples)) {
           _.each(_selectedSamples, function(caseId) {

--- a/app/scripts/views/components/dataTable/tableView.js
+++ b/app/scripts/views/components/dataTable/tableView.js
@@ -207,7 +207,6 @@
             }
           } else {
             datum.caseIds = _.uniq(item.caseIds);
-            //if(!initialLoaded)
             datum.samples = datum.caseIds.length;
             switch (type_) {
               case 'mutatedGene':
@@ -237,13 +236,9 @@
           } else {
             datum.qval = '';
           }
-
           genes.push(datum);
         })
       }
-      /*if(!initialLoaded){
-        initialLoaded = true;
-      }*/
       return genes;
 
     }
@@ -270,14 +265,7 @@
     }
 
     function reactSubmitClickCallback(){
-      var selectedSamplesUnion = _.pluck(selectedRowData,'caseIds');
-      $.each(selectedRowData, function(index,item){
-        var casesIds = item.caseIds.split(',');
-        selectedSamplesUnion = selectedSamplesUnion.concat(casesIds);
-      });
-      // selectedRowData = [];
-      callbacks_.submitClick(_.unique(selectedSamplesUnion));
-
+      callbacks_.submitClick(selectedRowData);
     }
 
     function reactRowClickCallback(data, selected, _selectedRows) {
@@ -286,26 +274,14 @@
       }
       else{
         selectedRowData = _.filter(selectedRowData, function(index,item){
-          if(item.uniqueId === selected.uniqueId){
-            return false;
-          }return true
-        })
+          return (item.uniqueId === selected.uniqueId);
+        });
       }
-      callbacks_.rowClick(selectedRowData.length>0);
-     /* var selectedRows_ = [];
-      _.each(_selectedRows, function(item) {
-        selectedRows_.push(item.uniqueId)
-      });
-      selectedRows = selectedRows_;
-      if (callbacks_.hasOwnProperty('rowClick')) {
-        callbacks_.rowClick(_selectedRows, data, selected);
-      }*/
     }
 
     function reactGeneClickCallback(selectedRow, selected) {
       callbacks_.addGeneClick(selectedRow);
     }
-
     return content;
   };
 

--- a/app/scripts/views/components/dataTable/tableView.js
+++ b/app/scripts/views/components/dataTable/tableView.js
@@ -55,7 +55,7 @@
       return _.intersection(selectedSamples, sequencedSampleIds);
     };
 
-    content.getselectedRowData = function() {
+    content.getSelectedRowData = function() {
       return selectedRowData;
     };
     content.clearSelectedRowData = function() {
@@ -153,18 +153,20 @@
         fixedChoose: false,
         uniqueId: 'uniqueId',
         rowHeight: 25,
-        tableWidth: 375,
+        tableWidth: 373,
         maxHeight: 290,
         headerHeight: 26,
         groupHeaderHeight: 40,
         autoColumnWidth: false,
         columnMaxWidth: 300,
         columnSorting: false,
-        selectedRow: selectedRows,
+        selectedRows: selectedRows,
         selectedGene: selectedGenes,
         rowClickFunc: reactRowClickCallback,
         geneClickFunc: reactGeneClickCallback,
-        submitClickFunc: reactSubmitClickCallback,
+        selectButtonClickCallback: reactSubmitClickCallback,
+        // sortBy: "name",
+        // sortDir: "DESC",
         tableType: type_
       };
       var testElement = React.createElement(EnhancedFixedDataTableSpecial,
@@ -273,7 +275,7 @@
         var casesIds = item.caseIds.split(',');
         selectedSamplesUnion = selectedSamplesUnion.concat(casesIds);
       });
-      selectedRowData = [];
+      // selectedRowData = [];
       callbacks_.submitClick(_.unique(selectedSamplesUnion));
 
     }
@@ -345,7 +347,7 @@
               "attr_id": "sampleRate",
               "display_name": "Freq",
               "datatype": "PERCENTAGE",
-              "column_width": 95
+              "column_width": 93
             },
             {
               "attr_id": "caseIds",
@@ -397,7 +399,7 @@
               "attr_id": "altrateInSample",
               "display_name": "Freq",
               "datatype": "PERCENTAGE",
-              "column_width": 80
+              "column_width": 78
             },
             {
               "attr_id": "caseIds",

--- a/app/scripts/views/components/dataTable/tableView.js
+++ b/app/scripts/views/components/dataTable/tableView.js
@@ -119,6 +119,8 @@
         } else {
           initReactTable(true);
         }
+      }else{
+        initReactTable(false);
       }
     };
 
@@ -172,6 +174,7 @@
           if (_selectedGenesMap !== undefined) {
             if (_selectedGenesMap[item.index] !== undefined) {
               datum.caseIds = _.uniq(_selectedGenesMap[item.index].caseIds);
+              datum.defaultCaseIds =  _.uniq(item.caseIds);
               datum.samples = datum.caseIds.length;
               switch (type_) {
                 case 'mutatedGene':
@@ -194,7 +197,7 @@
             }
           } else {
             datum.caseIds = _.uniq(item.caseIds);
-            if(!initialLoaded)
+            //if(!initialLoaded)
               datum.defaultCaseIds = datum.caseIds;
             datum.samples = datum.caseIds.length;
             switch (type_) {
@@ -229,9 +232,9 @@
           genes.push(datum);
         })
       }
-      if(!initialLoaded){
+      /*if(!initialLoaded){
         initialLoaded = true;
-      }
+      }*/
       return genes;
     }
 
@@ -247,7 +250,7 @@
           var datum = {
             attr_id: key,
             uniqueId: item.uniqueId,
-            attr_val: key === 'caseIds' ? item.caseIds.join(',') : item[key]
+            attr_val: key === 'caseIds' ? item.caseIds.join(',') : key === 'samples' ? item.samples+'('+item.defaultCaseIds.length+')' :item[key]
           };
           result.data.push(datum);
         }
@@ -303,8 +306,8 @@
             },
             {
               "attr_id": "samples",
-              "display_name": "#",
-              "datatype": "NUMBER",
+              "display_name": "#(Total number of Samples)",
+              "datatype": "STRING",
               "column_width": 90
             },
             {
@@ -355,8 +358,8 @@
             },
             {
               "attr_id": "samples",
-              "display_name": "#",
-              "datatype": "NUMBER",
+              "display_name": "#(Total number of Samples)",
+              "datatype": "STRING",
               "column_width": 70
             },
             {

--- a/app/scripts/views/components/dataTable/tableViewTemplate.js
+++ b/app/scripts/views/components/dataTable/tableViewTemplate.js
@@ -188,17 +188,16 @@
       var _self = this;
       var callbacks = {};
       var _selectedSampleList = this.$parent.$parent.$parent.selectedsamples;
-      var _completeSampleList = this.$parent.$parent.$parent.completeSamplesList;
       var _selectedGenes = this.$parent.$parent.$parent.$parent.selectedgenes;
 
       callbacks.addGeneClick = this.addGeneClick;
       callbacks.rowClick = this.rowClick;
       _self.chartInst = new iViz.view.component.tableView();
 
-      if(_completeSampleList.length === 0){
-        _completeSampleList = _selectedSampleList;
+      if(_selectedSampleList.length === 0){
+        _selectedSampleList = this.attributes['allCases'];
       }
-      _self.chartInst.init(_completeSampleList, _selectedSampleList, _selectedGenes, this.indices, this.attributes['gene_list'],this.data, this.chartId, this.attributes.type, callbacks);
+      _self.chartInst.init(this.attributes, _selectedSampleList, _selectedGenes, this.indices, this.data, this.chartId, callbacks);
       this.setDisplayTitle(this.chartInst.getCases().length);
       this.$dispatch('data-loaded', true);
     }

--- a/app/scripts/views/components/dataTable/tableViewTemplate.js
+++ b/app/scripts/views/components/dataTable/tableViewTemplate.js
@@ -56,8 +56,8 @@
         showLoad:true,
         showLoading:'show-loading',
         hideLoading:'hide-loading',
-        fromRowSelection:false,
-        updateTable:true
+        //fromRowSelection:false,
+        //updateTable:true
       };
     },
     watch: {
@@ -70,16 +70,16 @@
         genes = $.extend(true,[],genes);
         this.chartInst.updateGenes(genes);
       },'selected-sample-update': function(_selectedSamples) {
-        if(this.updateTable){
-          this.chartInst.update(_selectedSamples);
+        //if(this.updateTable){
+          this.chartInst.update(_selectedSamples, _.pluck(this.filters,'uniqueId'));
           this.setDisplayTitle(this.chartInst.getCases().length);
-        }else{
+        /*}else{
           this.updateTable = true;
           if(this.filters.length === 0){
             this.chartInst.update(_selectedSamples);
             this.setDisplayTitle(this.chartInst.getCases().length);
           }
-        }
+        }*/
       },
       'closeChart':function(){
         if(this.filters.length>0){
@@ -95,45 +95,46 @@
       }, mouseLeave: function() {
         this.showOperations = false;
       }, rowClick: function( data, clickedRowData, rowSelected) {
-        this.fromRowSelection = true;
-        this.updateTable = false;
-         var _filters = [];
+       // this.fromRowSelection = true;
+       // this.updateTable = true;
+        /* var _filters = [];
         var _caseIds = [];
           _.each(data,function(item,index){
             var _selectedGeneSamplesMap = {};
             _selectedGeneSamplesMap.uniqueId = item.uniqueId;
             _selectedGeneSamplesMap.caseIds = [];
+            _selectedGeneSamplesMap.defaultCaseIds = item.defaultCaseIds;
             _caseIds = _caseIds.concat(item.caseIds.split(','));
             _filters.push(_selectedGeneSamplesMap);
           });
         _caseIds = _.unique(_caseIds);
         _.map(_filters,function(item){
           item.caseIds = _caseIds;
-        });
+        });*/
 
-          this.filters = _filters;
+          this.filters = data;
       }, addGeneClick: function(clickedRowData) {
         this.$dispatch('manage-gene',clickedRowData.gene);
       }, setDisplayTitle: function(numOfCases) {
         this.displayName = this.attributes.display_name+'('+numOfCases+' profiled samples)';
       }, updateFilters: function(newVal,removeChart){
-        var _samples = [];
-        if(!removeChart){
+       // var _samples = [];
+        /*if(!removeChart){
         if(this.fromRowSelection){
           this.fromRowSelection = false;
-          if(newVal.length>0){
+          /!*if(newVal.length>0){
             _.each(newVal,function(item,index){
               _samples = _samples.concat(item.caseIds);
             });
             _samples = _.unique(_samples);
           }else{
             _samples = this.chartInst.getCases();
-          }
+          }*!/
         }else{
-          this.fromRowSelection = true;
-          this.updateTable = true;
-          var _selectedRows = [];
-          if(newVal.lenght>0){
+          //this.fromRowSelection = true;
+         // this.updateTable = true;
+          /!*var _selectedRows = [];
+          if(newVal.length>0){
             _.each(newVal,function(item,index){
               _samples = _samples.concat(item.caseIds);
               _selectedRows.push(item.uniqueId)
@@ -142,10 +143,11 @@
           }else{
             _samples = this.chartInst.getCases();
           }
-          this.chartInst.update(_samples,_selectedRows);
+          console.log(_selectedRows)*!/
+          //this.chartInst.update(_samples,_selectedRows);
         }
-        }
-        this.$dispatch('update-samples-from-table',_samples);
+        }*/
+        this.$dispatch('update-samples-from-table');
       }
 
     },

--- a/app/scripts/views/components/dataTable/tableViewTemplate.js
+++ b/app/scripts/views/components/dataTable/tableViewTemplate.js
@@ -39,7 +39,7 @@
     '<chart-operations :show-operations="showOperations" :display-name="displayName" ' +
     ':has-chart-title="true" :groupid="groupid" :reset-btn-id="resetBtnId" :chart="chartInst" ' +
     ':chart-id="chartId" :attributes="attributes" :filters.sync="filters" :filters.sync="filters"></chart-operations>' +
-    '<div class="study-view-loader" style="display: block;z-index: 5;position:absolute;right:0px;bottom:0px;" v-if="hasfilters"> <button type="button" @click="submitClick()">Submit</button> </div>' +
+    // '<div class="study-view-loader" style="display: block;z-index: 5;position:absolute;right:0px;bottom:0px;" v-if="hasfilters"> <button type="button" @click="submitClick()">Submit</button> </div>' +
     '<div class="dc-chart dc-table-plot" :class="{hideLoading: showLoad}" align="center" style="float:none !important;" id={{chartId}} >' +
 
     '</div>',
@@ -102,7 +102,7 @@
         this.showOperations = false;
       }, submitClick:function(selectedSample){
         var selectedSamplesUnion = [];
-        var temp_ = this.chartInst.getselectedRowData();
+        var temp_ = this.chartInst.getSelectedRowData();
         var selectedRowsUids = _.pluck(temp_,'uniqueId');
         this.selectedRows = _.union(this.selectedRows,selectedRowsUids);
         $.each(temp_, function(index,item){
@@ -192,6 +192,7 @@
 
       callbacks.addGeneClick = this.addGeneClick;
       callbacks.rowClick = this.rowClick;
+      callbacks.submitClick = this.submitClick;
       _self.chartInst = new iViz.view.component.tableView();
 
       if(_selectedSampleList.length === 0){

--- a/app/scripts/views/components/dataTable/tableViewTemplate.js
+++ b/app/scripts/views/components/dataTable/tableViewTemplate.js
@@ -128,7 +128,7 @@
       _self.chartInst = new iViz.view.component.tableView();
 
       if(_selectedSampleList.length === 0){
-        _selectedSampleList = this.attributes['allCases'];
+        _selectedSampleList = this.attributes.options['allCases'];
       }
       _self.chartInst.init(this.attributes, _selectedSampleList, _selectedGenes, this.indices, this.data, this.chartId, callbacks);
       this.setDisplayTitle(this.chartInst.getCases().length);

--- a/app/scripts/views/components/header/breadCrumbTemplate.js
+++ b/app/scripts/views/components/header/breadCrumbTemplate.js
@@ -38,7 +38,7 @@
     template: 
       '<span class="breadcrumb_container" v-if="attributes.filter.length > 0">' +
         '<span>{{attributes.display_name}}</span>' +
-        '<span v-if="attributes.attr_id !== \'MUT_CNT_VS_CNA\'" class="breadcrumb_items">' +
+        '<span v-if="(attributes.attr_id !== \'MUT_CNT_VS_CNA\')&&(attributes.view_type ! == \'table\')" class="breadcrumb_items">' +
           '<span v-if="filters.filterType === \'RangedFilter\'">' +
             '<span class="breadcrumb_item">{{filters[0]}} -- {{filters[1]}}</span>' +
             '<img class="breadcrumb_remove" src="../../../../images/remove_breadcrumb_icon.png" @click="removeFilter(filters)">' +
@@ -71,9 +71,10 @@
         } else if(this.attributes.view_type === 'scatter_plot'){
           this.filters = [];
         }else if(this.attributes.view_type === 'table'){
-          var filters_ = $.extend(true,[],this.filters);
+          this.filters = [];
+        /*  var filters_ = $.extend(true,[],this.filters);
           filters_ = _.reject(filters_, function(el) { return el.uniqueId === val.uniqueId; });
-          this.filters = filters_;
+          this.filters = filters_;*/
         }
       }
     }

--- a/app/scripts/views/components/pieChart/pieChart.js
+++ b/app/scripts/views/components/pieChart/pieChart.js
@@ -536,7 +536,7 @@
         columnMaxWidth: 300,
         columnSorting: false,
         tableType: 'pieLabel',
-        selectedRow: selectedRows,
+        selectedRows: selectedRows,
         rowClickFunc: pieLabelClick
       }, opts);
 

--- a/app/scripts/views/mainTemplate.js
+++ b/app/scripts/views/mainTemplate.js
@@ -112,16 +112,11 @@
                     _scatterPlotSel =attributes.filter;
                   }
                 } else if (attributes.view_type === 'table') {
-                  var _tableSelTemp = [];
-                  _.each(attributes.filter,function(tableFilter,index){
-                    var _samples = tableFilter.defaultCaseIds;
-                    if(_tableSelTemp.length !== 0){
-                      _tableSelTemp = _.union(_tableSelTemp,_samples);
-                    }else{
-                      _tableSelTemp = _samples;
-                    }
-                  });
-                  _tableSel.push(_tableSelTemp);
+                  if(_tableSel.length !== 0){
+                    _tableSel = _.intersection(_tableSel,attributes.filter);
+                  }else{
+                    _tableSel =attributes.filter;
+                  }
                 } else{
                   filters_[attributes.attr_id] = attributes.filter;
                 }
@@ -134,12 +129,6 @@
               _.intersection(_selectedSamplesByFiltersOnly, _scatterPlotSel);
           }
           if (_tableSel.length !== 0) {
-           // if(_tableSel.length>1){
-              _tableSel = _.intersection.apply(_, _tableSel);
-           // }else{
-             // _tableSel = _tableSel[0]
-           // }
-
             _selectedSamplesByFiltersOnly =
               _.intersection(_selectedSamplesByFiltersOnly, _tableSel);
           }

--- a/app/scripts/views/mainTemplate.js
+++ b/app/scripts/views/mainTemplate.js
@@ -112,12 +112,16 @@
                     _scatterPlotSel =attributes.filter;
                   }
                 } else if (attributes.view_type === 'table') {
-                  var _samples = attributes.filter[0].caseIds;
-                  if(_scatterPlotSel.length !== 0){
-                    _tableSel = _.intersection(_tableSel,_samples);
-                  }else{
-                    _tableSel = _samples;
-                  }
+                  var _tableSelTemp = [];
+                  _.each(attributes.filter,function(tableFilter,index){
+                    var _samples = tableFilter.defaultCaseIds;
+                    if(_tableSelTemp.length !== 0){
+                      _tableSelTemp = _.union(_tableSelTemp,_samples);
+                    }else{
+                      _tableSelTemp = _samples;
+                    }
+                  });
+                  _tableSel.push(_tableSelTemp);
                 } else{
                   filters_[attributes.attr_id] = attributes.filter;
                 }
@@ -130,6 +134,12 @@
               _.intersection(_selectedSamplesByFiltersOnly, _scatterPlotSel);
           }
           if (_tableSel.length !== 0) {
+           // if(_tableSel.length>1){
+              _tableSel = _.intersection.apply(_, _tableSel);
+           // }else{
+             // _tableSel = _tableSel[0]
+           // }
+
             _selectedSamplesByFiltersOnly =
               _.intersection(_selectedSamplesByFiltersOnly, _tableSel);
           }

--- a/app/styles/vendor/_efdt.scss
+++ b/app/styles/vendor/_efdt.scss
@@ -60,7 +60,10 @@
         line-height: 12px;
       }
     }
-
+    .EFDT-finish-selection-button {
+      float: right;
+      margin: 3px 0;
+    }
     .EFDT-header {
       text-align: center;
       vertical-align: middle;


### PR DESCRIPTION
The new logic table row selection is bit different compared to existing study-view tables. Instead of refreshing all the charts user would be displayed a 'select' button in the table div once user checks on interested gene-samples row(s). Once select button is clicked selected samples would be union of the selected row samples. And if the user next selects more rows and clicks submit again, then first step would be union within the selected rows and next step is intersection between previous selected cases and current selected cases.
