### PR TITLE
Fix the bug: exclude NA does not work in combination chart

### DIFF
--- a/app/scripts/model/dataProxy.js
+++ b/app/scripts/model/dataProxy.js
@@ -711,7 +711,7 @@ window.DataManagerForIviz = (function($, _) {
                     _mutCntAttrMeta.keys = {};
                     _mutCntAttrMeta.numOfDatum = 0;
                     _mutCntAttrMeta.priority = 2;
-                    _mutCntAttrMeta.attrList = ['cna_fraction'];
+                    _mutCntAttrMeta.attrList = ['mutation_count', 'cna_fraction'];
                     _sampleAttributes[_mutCntAttrMeta.attr_id] = _mutCntAttrMeta;
                   }
 

--- a/app/scripts/views/components/survivalChart/components/curve.js
+++ b/app/scripts/views/components/survivalChart/components/curve.js
@@ -102,19 +102,20 @@
     _self.elem_.curves = {};
   };
 
-  iViz.view.component.SurvivalCurve.prototype.addCurve = function(_data,
+  iViz.view.component.SurvivalCurve.prototype.addCurve = function(data,
     _curveIndex,
     _lineColor) {
     var _self = this;
+    var _data = data;
 
     // add an empty/zero point so the curve starts from zero time point
     if (_data !== null && _data.length !== 0) {
       if (_data[0].time !== 0) {
-        _data.unshift({
+        _data = [{
           status: 0,
           survival_rate: 1,
           time: 0
-        });
+        }].concat(_data);
       }
     }
 
@@ -265,8 +266,6 @@
     function(_selectedData, _unselectedData) {
       var _self = this;
       _self.elem_.svg.selectAll('.pval').remove();
-      _selectedData.splice(0, 1);
-      _unselectedData.splice(0, 1);
       var _pVal = LogRankTest.calc(_selectedData, _unselectedData);
       _self.elem_.svg.append('text')
         .attr('class', 'pval')
@@ -313,8 +312,10 @@
         } else {
           _self.opts_.curves[curveIndex].highlighted = true;
         }
+        // Don't highlight the time equal to 0. This is a fake node added
+        // in addCurve function
         _self.elem_.curves[curveIndex].invisibleDots
-          .selectAll('path')
+          .selectAll('path:not([time="0"])')
           .style('opacity', opacity);
       }
     };

--- a/app/scripts/views/components/survivalChart/template.js
+++ b/app/scripts/views/components/survivalChart/template.js
@@ -144,10 +144,16 @@
                 nonNaCases: []
               };
             }
-            filteredClinicalAttrs[group.id].attrs =
-              _.pluck(_.filter(group.attributes, function(attr) {
-                return attr.filter.length > 0;
-              }), 'attr_id');
+            filteredClinicalAttrs[group.id].attrs = [];
+            
+            // Loop through attrList instead of only using attr_id
+            // Combination chart has its own attr_id, but the clinical data
+            // it's using are listed under attrList
+            _.each(_.filter(group.attributes, function(attr) {
+              return attr.filter.length > 0;
+            }), function(item) {
+              filteredClinicalAttrs[group.id].attrs.push(_.pick(item, 'attr_id', 'attrList'));
+            });
           });
           if (this.excludeNa) {
             // Find qualified cases in each group.
@@ -159,7 +165,7 @@
                 var hasNaWithinAttrs = false;
 
                 //Check whether case contains NA value on filtered attrs
-                _.some(group.attrs, function(attr) {
+                _.some(_.flatten(_.pluck(group.attrs, 'attrList')), function(attr) {
                   if (iViz.util.strIsNa(data[attr], false)) {
                     hasNaWithinAttrs = true;
                     return true;


### PR DESCRIPTION
Close issue https://github.com/cBioPortal/cbioportal/issues/2800;
Do not highlight the first survival node in each curve which is created
as a fake node;
Don’t change the input data array directly;