### PR TITLE
Fix barchart '<=max' and '>min' issue.

### DIFF
--- a/app/scripts/views/components/barChart/barChart.js
+++ b/app/scripts/views/components/barChart/barChart.js
@@ -173,17 +173,19 @@
       } else if (v === opts_.emptyMappingVal || opts_.xDomain.length === 1) {
         return 'NA';
       } else if (v === opts_.xDomain[0]) {
-        formattedValue = opts_.xDomain[1];
+        // In case '<=max' and '>min' occurring
+        formattedValue = opts_.xDomain[1] < opts_.xDomain[opts_.xDomain.length - 1] ? opts_.xDomain[1] : opts_.xDomain[0];
         if (data_.smallDataFlag) {
           return '<=' + e(formattedValue);
         }
         return '<=' + formattedValue;
       } else if ((v === opts_.xDomain[opts_.xDomain.length - 2] && data_.hasNA) ||
         (v === opts_.xDomain[opts_.xDomain.length - 1] && !data_.hasNA)) {
+        // In case '<=max' and '>min' occurring
         if (data_.hasNA) {
-          formattedValue = opts_.xDomain[opts_.xDomain.length - 3];
+          formattedValue = opts_.xDomain[opts_.xDomain.length - 3] > opts_.xDomain[0] ? opts_.xDomain[opts_.xDomain.length - 3] : opts_.xDomain[opts_.xDomain.length - 2];
         } else {
-          formattedValue = opts_.xDomain[opts_.xDomain.length - 2];
+          formattedValue = opts_.xDomain[opts_.xDomain.length - 2] > opts_.xDomain[0] ? opts_.xDomain[opts_.xDomain.length - 2] : opts_.xDomain[opts_.xDomain.length - 1];
         }
         if (data_.smallDataFlag) {
           return '>' + e(formattedValue);


### PR DESCRIPTION
When there are only 2 ticks, it may happen '<=max' and '>min' issue. We compare fomattedValue with max and min to get accurate ticks.

Fix #623 