### PR TITLE
Switch to new api & performance improvment

### DIFF
--- a/app/scripts/controller/util.js
+++ b/app/scripts/controller/util.js
@@ -845,6 +845,10 @@ var util = (function(_, cbio) {
       }
       return message;
     };
+    
+    content.getHypotenuse = function(a, b) {
+      return Math.sqrt(Math.pow(a, 2) + Math.pow(b, 2));
+    };
 
     return content;
   })();

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -127,10 +127,6 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
         vm_.selectedpatientUIDs = _.pluck(data_.groups.patient.data, 'patient_uid');
         vm_.groups = groups;
         vm_.charts = charts;
-        vm_.$nextTick(function() {
-          _self.fetchCompleteData('patient');
-          _self.fetchCompleteData('sample');
-        });
       });
     }, // ---- close init function ----groups
     createGroupNdx: function(group) {

--- a/app/scripts/model/dataProxy.js
+++ b/app/scripts/model/dataProxy.js
@@ -827,6 +827,7 @@ window.DataManagerForIviz = (function($, _) {
                 _profile.push({
                   id: profile.molecularProfileId,
                   study_id: profile.studyId,
+                  datatype: profile.datatype,
                   genetic_alteration_type: profile.molecularAlterationType
                 });
                 profiles[profile.studyId] = _profile;
@@ -898,10 +899,10 @@ window.DataManagerForIviz = (function($, _) {
                   description: attribute.description,
                   display_name: attribute.displayName,
                   is_patient_attribute: attribute.patientAttribute ? "1" : "0",
-                  prority: attribute.priority
+                  priority: attribute.priority
                 });
                 attributes[attribute.studyId] = _attribute;
-              });c
+              });
               var selectedAttributes = _.pick(attributes, self.getCancerStudyIds());
               var clinical_attributes_set = {};
               _.each(selectedAttributes, function(studyAttributes, studyId) {

--- a/app/scripts/model/dataProxy.js
+++ b/app/scripts/model/dataProxy.js
@@ -74,7 +74,7 @@ window.DataManagerForIviz = (function($, _) {
       var _def = new $.Deferred();
       var self = this;
       $.when(self.getSampleLists()).done(function() {
-        $.when(self.getStudyToSampleToPatientdMap(), self.getConfigs()).done(function(_studyToSampleToPatientMap, _configs) {
+        $.when(self.getStudyToSampleToPatientMap(), self.getConfigs()).done(function(_studyToSampleToPatientMap, _configs) {
           $.when(self.getGeneticProfiles(), self.getCaseLists(),
             self.getClinicalAttributesByStudy())
             .done(function(_geneticProfiles, _caseLists,
@@ -950,7 +950,7 @@ window.DataManagerForIviz = (function($, _) {
               fetch_promise.reject(error);
             });
         }),
-      getStudyToSampleToPatientdMap: window.cbio.util.makeCachedPromiseFunction(
+      getStudyToSampleToPatientMap: window.cbio.util.makeCachedPromiseFunction(
         function(self, fetch_promise) {
           var study_to_sample_to_patient = {};
           var _sample_uid = 0;
@@ -1042,7 +1042,10 @@ window.DataManagerForIviz = (function($, _) {
 
           var _sampleLists = [];
           _.each(self.getCancerStudyIds(), function(studyId) {
-            _sampleLists.push(studyId + '_all');
+            self.data.sampleLists[studyId] = self.data.sampleLists[studyId] || {};
+            if (!_.isArray(self.studyCasesMap[studyId].samples)) {
+              _sampleLists.push(studyId + '_all');
+            }
           });
 
           self.getSampleListsData(_sampleLists)

--- a/app/scripts/model/dataProxy.js
+++ b/app/scripts/model/dataProxy.js
@@ -102,21 +102,15 @@ window.DataManagerForIviz = (function($, _) {
               iViz.priorityManager.setDefaultClinicalAttrPriorities(_configs.priority);
 
               _.each(_caseLists, function(caseList, studyId) {
-                if (caseList.cnaSampleIds.length > 0) {
-                  _.each(caseList.cnaSampleIds, function(sampleId, index) {
-                    _cnaCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
-                  });
-                }
-                if (caseList.sequencedSampleIds.length > 0) {
-                  _.each(caseList.sequencedSampleIds, function(sampleId, index) {
-                    _sequencedCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
-                  });
-                }
-                if (caseList.allSampleIds.length > 0) {
-                  _.each(caseList.allSampleIds, function(sampleId, index) {
-                    _allCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
-                  });
-                }
+                _.each(caseList.cnaSampleIds, function(sampleId) {
+                  _cnaCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
+                });
+                _.each(caseList.sequencedSampleIds, function(sampleId) {
+                  _sequencedCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
+                });
+                _.each(caseList.allSampleIds, function(sampleId) {
+                  _allCaseUIDs.push(_studyToSampleToPatientMap[studyId].sample_to_uid[sampleId]);
+                });
               });
               _cnaCaseUIDs = _cnaCaseUIDs.length > 0 ? _cnaCaseUIDs : _allCaseUIDs;
               _sequencedCaseUIDs = _sequencedCaseUIDs.length > 0 ? _sequencedCaseUIDs : _allCaseUIDs;

--- a/app/scripts/views/components/barChart/barChart.js
+++ b/app/scripts/views/components/barChart/barChart.js
@@ -494,7 +494,7 @@
       var groups = dcDimension.group().top(Infinity);
       var groupTypeId =
         data_.groupType === 'patient' ? 'patient_uid' : 'sample_uid';
-      var selectedCases = _.pluck(dcDimension.top(Infinity), groupTypeId);
+      var selectedCases = _.pluck(dcDimension.top(Infinity), groupTypeId).sort();
       var categories = [];
       var colorCounter = 0;
 
@@ -515,7 +515,7 @@
             key: group.key,
             name: mapTickToCaseIds[group.key].range || mapTickToCaseIds[group.key].tick,
             color: color,
-            caseIds: _.intersection(selectedCases, mapTickToCaseIds[group.key].caseIds)
+            caseIds: iViz.util.intersection(selectedCases, mapTickToCaseIds[group.key].caseIds.sort())
           });
         }
       });

--- a/app/scripts/views/components/barChart/barChartTemplate.js
+++ b/app/scripts/views/components/barChart/barChartTemplate.js
@@ -149,10 +149,11 @@
         var _dataIssue = false;
         var smallerOutlier = [];
         var greaterOutlier = [];
+        var dataMetaKeys = {}; // Fast index unique dataMeta instead of using _.unique
 
         this.data.meta = _.map(_.filter(_.pluck(
           _data, this.opts.attrId), function(d) {
-          if (iViz.util.strIsNa(d, true) || (isNaN(d) && !d.includes('>') && !d.includes('<'))) {
+          if (isNaN(d) && !(_.isString(d) && d.includes('>') && d.includes('<'))) {
             _self.data.hasNA = true;
             d = 'NA';
           }
@@ -172,6 +173,7 @@
           } else {
             number = parseFloat(d);
           }
+          dataMetaKeys[number] = true;
           return number;
         });
 
@@ -202,7 +204,7 @@
             // noGrouping is true when number of different values less than or equal to 5. 
             // In this case, the chart sets data value as ticks' value directly. 
             this.data.noGrouping = false;
-            if (_.unique(this.data.meta).length <= 5 && this.data.meta.length > 0) {// for data less than 6 points
+            if (Object.keys(dataMetaKeys).length <= 5 && this.data.meta.length > 0) {// for data less than 6 points
               this.data.noGrouping = true;
               this.data.uniqueSortedData = _.unique(findExtremeResult[3]);// use sorted value as ticks directly
             }

--- a/app/scripts/views/components/shareVirtualStudy/shareVirtualStudy.js
+++ b/app/scripts/views/components/shareVirtualStudy/shareVirtualStudy.js
@@ -105,50 +105,21 @@
                   var saveCohort = false;
 
                   if (_.isObject(self_.stats.studies)) {
-                    var selectedCasesMap = {};
-                    _.each(self_.stats.studies, function(study){
-                      selectedCasesMap[study.id] = study;
-                    });
-
                     // When a user clicks copy, it will trigger saving the current virtual cohort and return the url 
                     // to the user. When a user want to see the cohort url, he/she needs to click Share button. 
                     // We always show the url to user but we don't need to same virtual cohort every time 
                     // if it is same with the previous saved cohort.
-                    if (_.isEmpty(previousSelectedCases)) {
+
+                    var currentSelectedCases = JSON.stringify(self_.stats.studies) + JSON.stringify(self_.stats);
+
+                    if (currentSelectedCases !== previousSelectedCases) {
                       saveCohort = true;
-                    } else {
-                      _.every(selectedCasesMap, function(selectedCase){
-                        if(previousSelectedCases[selectedCase.id]){
-                          var previousCase = previousSelectedCases[selectedCase.id];
-                          if (previousCase.patients.length !== selectedCase.patients.length ||
-                            previousCase.samples.length !== selectedCase.samples.length) {
-                            saveCohort = true;
-                          } else if (previousCase.patients.length ===
-                            selectedCase.patients.length) {
-                            var differentPatients = _.difference(previousCase.patients,
-                              selectedCase.patients);
-                            if (differentPatients.length > 0) {
-                              saveCohort = true;
-                            }
-                          } else if (previousCase.samples.length ===
-                            selectedCase.samples.length) {
-                            var differentSamples = _.difference(previousCase.samples,
-                              selectedCase.samples);
-                            if (differentSamples.length > 0) {
-                              saveCohort = true;
-                            }
-                          }
-                        }
-                        return !saveCohort;
-                      });
                     }
 
                     if (saveCohort) {
                       vcSession.events.saveCohort(self_.stats,
                         cohortName, cohortDescription || '')
                         .done(function (response) {
-                          var deepCopySelectedCases = JSON.parse(
-                            JSON.stringify(self_.stats.studies));
                           self_.savedVC = response;
                           tooltip.find('.cohort-link').html(
                             '<a class="virtual-study-link" href="' + window.cbioURL +
@@ -157,9 +128,7 @@
                             window.cbioURL + 'study?id=' + self_.savedVC.id + '</a>');
                           tooltip.find('.saving').css('display', 'none');
                           tooltip.find('.cohort-link').css('display', 'block');
-                          _.each(deepCopySelectedCases, function(study){
-                            previousSelectedCases[study.id] = study;
-                          });
+                          previousSelectedCases = currentSelectedCases;
                         })
                         .fail(function () {
                           tooltip.find('.failedMessage').html(

--- a/app/scripts/views/components/shareVirtualStudy/shareVirtualStudy.js
+++ b/app/scripts/views/components/shareVirtualStudy/shareVirtualStudy.js
@@ -102,21 +102,14 @@
                 self_.updateStats = true;
 
                 self_.$nextTick(function() {
-                  var saveCohort = false;
-
                   if (_.isObject(self_.stats.studies)) {
                     // When a user clicks copy, it will trigger saving the current virtual cohort and return the url 
                     // to the user. When a user want to see the cohort url, he/she needs to click Share button. 
                     // We always show the url to user but we don't need to same virtual cohort every time 
                     // if it is same with the previous saved cohort.
-
                     var currentSelectedCases = JSON.stringify(self_.stats.studies) + JSON.stringify(self_.stats);
 
                     if (currentSelectedCases !== previousSelectedCases) {
-                      saveCohort = true;
-                    }
-
-                    if (saveCohort) {
                       vcSession.events.saveCohort(self_.stats,
                         cohortName, cohortDescription || '')
                         .done(function (response) {

--- a/app/scripts/views/components/survivalChart/components/curve.js
+++ b/app/scripts/views/components/survivalChart/components/curve.js
@@ -126,7 +126,7 @@
     var _dataLength = _data.length;
 
     // Only do the data optimization on more than 5000 data points.
-    if (_dataLength > 5000) {
+    if (_dataLength > 2000) {
       var _dataTime = _.pluck(_data, 'time');
       var _dataSurvivalRate = _.pluck(_data, 'survival_rate');
 

--- a/app/scripts/views/components/survivalChart/proxy.js
+++ b/app/scripts/views/components/survivalChart/proxy.js
@@ -8,15 +8,6 @@
  */
 (function(iViz, kmEstimator, _) {
   iViz.data.SurvivalChartProxy = function(_data, _attrId) {
-    var datum_ = {
-      study_id: '',
-      patient_id: '',
-      patient_uid: '',
-      time: '', // num of months
-      status: '',
-      num_at_risk: -1,
-      survival_rate: 0
-    };
     var datumArr_ = [];
 
     // convert raw data
@@ -34,7 +25,15 @@
       if (!isNaN(_time) &&
         _status !== 'NaN' && _status !== 'NA' &&
         typeof _status !== 'undefined' && typeof _time !== 'undefined') {
-        var _datum = jQuery.extend(true, {}, datum_);
+        var _datum = {
+          study_id: '',
+          patient_id: '',
+          patient_uid: '',
+          time: '', // num of months
+          status: '',
+          num_at_risk: -1,
+          survival_rate: 0
+        };
         _datum.patient_uid = _dataObj.patient_uid;
         _datum.patient_id = iViz.getCaseIdUsingUID('patient', _dataObj.patient_uid);
         _datum.study_id = _dataObj.study_id;

--- a/app/scripts/views/components/survivalChart/template.js
+++ b/app/scripts/views/components/survivalChart/template.js
@@ -161,12 +161,20 @@
               var data_ = iViz.getGroupNdx(_groupId);
               var nonNaCases = [];
 
+              //Check whether case contains NA value on filtered attrs
+              var _attrs = {};
+              _.each(group.attrs, function(groupAttr) {
+                _.each(groupAttr.attrList, function(listItem) {
+                  _attrs[listItem] = 1;
+                })
+              });
+              _attrs = Object.keys(_attrs);
+
               _.each(data_, function(data) {
                 var hasNaWithinAttrs = false;
-
-                //Check whether case contains NA value on filtered attrs
-                _.some(_.flatten(_.pluck(group.attrs, 'attrList')), function(attr) {
-                  if (iViz.util.strIsNa(data[attr], false)) {
+                _.some(_attrs, function(attr) {
+                  // All data has been normalized to NA for different NA values
+                  if (data[attr] === 'NA') {
                     hasNaWithinAttrs = true;
                     return true;
                   }


### PR DESCRIPTION
1. Switch to new POST APIs
2. Performance improvement
    - Remove iViz.util.strIsNa check, isNaN can handle most of the cases
    - Calculate dataMetaKeys in object instead of using _.unique
    - Replace jQuery each with underscore each
    - Only calculate hasMutationData/hasSnaSegmentData once
    - Remember which study contains clinical attribute
    - Sort clinical attribute based on # of studies first
    - Calculate whether clinical attributes is preselected attr by regex,
this is O(n) instead of previous O(n2)
    - Do not sort clinical attrs when first time initializes result.groups.
They will be calculated in the following step
    - Update preSelectClinicalAttrRegex, make it more efficient
    - Calculate group attrs only once
    - No need to call strIsNa since data all have been normalization to NA
    - Optimize survival plot when # of dots more than 5000, decrease
the number of patients used generating survival plot. The threshold is
sqrt(pow(time max- time min) + pow(survival rate max- survival rate
min))