### PR TITLE
Performance improvement

### DIFF
--- a/app/scripts/controller/util.js
+++ b/app/scripts/controller/util.js
@@ -661,15 +661,36 @@ var util = (function(_, cbio) {
       return result;
     };
 
-    content.compare = function(arr1, arr2) {
-      if (arr1.length === arr2.length) {
-        for (var i = 0; i < arr1.length; i++) {
-          if (arr1[i] !== arr2[i]) {
-            return false;
-          }
+    /**
+     * Returns a copy of the array with values from array that are not present in the other array.
+     *
+     * @param {array} a Array, must already be sorted
+     * @param {array} b The other array, must already be sorted
+     * @return {array} The difference values
+     */
+    content.difference = function(a, b) {
+      var result = [];
+      var i = 0;
+      var j = 0;
+      var aL = a.length;
+      var bL = b.length;
+      while (i < aL && j < bL) {
+        if (a[i] < b[j]) {
+          result.push(a[i]);
+          ++i;
+        } else if (a[i] > b[j]) {
+          ++j;
+        } else {
+          ++i;
+          ++j;
         }
       }
-      return false;
+
+      return result;
+    };
+
+    content.compare = function(arr1, arr2) {
+      return JSON.stringify(arr1) === JSON.stringify(arr2);
     };
 
     content.getClinicalAttrTooltipContent = function(attribute) {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -342,7 +342,7 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
             _mutGeneMeta[_uniqueId] = {};
             _mutGeneMeta[_uniqueId].gene = _uniqueId;
             _mutGeneMeta[_uniqueId].num_muts = 1;
-            _mutGeneMeta[_uniqueId].case_uids = [_caseUIdIndex];
+            _mutGeneMeta[_uniqueId].case_ids = [_caseUIdIndex];
             _mutGeneMeta[_uniqueId].qval = (window.iviz.datamanager.getCancerStudyIds().length === 1 && _mutGeneDataObj.hasOwnProperty('qval')) ? _mutGeneDataObj.qval : null;
             _mutGeneMeta[_uniqueId].index = _mutGeneMetaIndex;
             if (data_.groups.sample.data[_caseUIdIndex].mutated_genes === undefined) {
@@ -353,7 +353,7 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
             _mutGeneMetaIndex += 1;
           } else {
             _mutGeneMeta[_uniqueId].num_muts += 1;
-            _mutGeneMeta[_uniqueId].case_uids.push(_caseUIdIndex);
+            _mutGeneMeta[_uniqueId].case_ids.push(_caseUIdIndex);
             if (data_.groups.sample.data[_caseUIdIndex].mutated_genes === undefined) {
               data_.groups.sample.data[_caseUIdIndex].mutated_genes = [_mutGeneMeta[_uniqueId].index];
             } else {
@@ -362,6 +362,11 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
           }
         });
       });
+
+      _.each(_mutGeneMeta, function(content) {
+        content.case_uids = iViz.util.unique(content.case_ids);
+      });
+      
       tableData_.mutated_genes = {};
       tableData_.mutated_genes.geneMeta = _mutGeneMeta;
       return tableData_.mutated_genes;
@@ -392,7 +397,7 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
               _cnaMeta[_uniqueId].gene = _geneSymbol;
               _cnaMeta[_uniqueId].cna = _altType;
               _cnaMeta[_uniqueId].cytoband = _cnaDataPerStudy.cytoband[_index];
-              _cnaMeta[_uniqueId].case_uids = [_caseIdIndex];
+              _cnaMeta[_uniqueId].case_ids = [_caseIdIndex];
               if ((window.iviz.datamanager.getCancerStudyIds().length !== 1) || _cnaDataPerStudy.gistic[_index] === null) {
                 _cnaMeta[_uniqueId].qval = null;
               } else {
@@ -406,7 +411,7 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
               }
               _cnaMetaIndex += 1;
             } else {
-              _cnaMeta[_uniqueId].case_uids.push(_caseIdIndex);
+              _cnaMeta[_uniqueId].case_ids.push(_caseIdIndex);
               if (data_.groups.sample.data[_caseIdIndex].cna_details === undefined) {
                 data_.groups.sample.data[_caseIdIndex].cna_details = [_cnaMeta[_uniqueId].index];
               } else {
@@ -416,6 +421,11 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
           });
         });
       });
+
+      _.each(_cnaMeta, function(content) {
+        content.case_uids = iViz.util.unique(content.case_ids);
+      });
+      
       tableData_.cna_details = {};
       tableData_.cna_details.geneMeta = _cnaMeta;
       return tableData_.cna_details;

--- a/app/scripts/views/components/dataTable/tableView.js
+++ b/app/scripts/views/components/dataTable/tableView.js
@@ -127,17 +127,22 @@
                     if (includeMutationCount) {
                       selectedMap_[geneIndex].num_muts = 1;
                     }
-                    selectedMap_[geneIndex].case_uids = [caseId];
+                    selectedMap_[geneIndex].case_ids = [caseId];
                   } else {
                     if (includeMutationCount) {
                       selectedMap_[geneIndex].num_muts += 1;
                     }
-                    selectedMap_[geneIndex].case_uids.push(caseId);
+                    selectedMap_[geneIndex].case_ids.push(caseId);
                   }
                 });
               }
             }
           });
+          
+          _.each(selectedMap_, function(content) {
+            content.case_uids = iViz.util.unique(content.case_ids);
+          });
+          
           initReactTable(true, selectedMap_, selectedSamples);
         }
       } else {
@@ -298,7 +303,7 @@
           var freq = 0;
           datum.gene = item.gene;
           if (_selectedGenesMap === undefined) {
-            datum.case_uids = iViz.util.unique(item.case_uids);
+            datum.case_uids = item.case_uids;
             datum.cases = datum.case_uids.length;
             datum.uniqueId = index;
             if (typeof genePanelMap[item.gene] !== 'undefined') {
@@ -323,8 +328,7 @@
             if (_selectedGenesMap[item.index] === undefined) {
               return;
             }
-            datum.case_uids =
-              iViz.util.unique(_selectedGenesMap[item.index].case_uids);
+            datum.case_uids = _selectedGenesMap[item.index].case_uids;
             datum.cases = datum.case_uids.length;
             if (typeof genePanelMap[item.gene] !== 'undefined') {
               freq = iViz.util.calcFreq(datum.cases, genePanelMap[item.gene]["sample_num"]);

--- a/app/scripts/views/components/survivalChart/template.js
+++ b/app/scripts/views/components/survivalChart/template.js
@@ -205,7 +205,7 @@
                     }
                   }
                   if (_.isArray(_caseId)) {
-                    nonNaCases = nonNaCases.concat(_caseId);
+                    nonNaCases.push.apply(nonNaCases, _caseId);
                   } else {
                     nonNaCases.push(_caseId);
                   }
@@ -227,7 +227,7 @@
             _allCases = iViz.util.intersection(_nonNaCases, _allCases);
           } else {
             _selectedCases =
-              _.pluck(this.invisibleDimension.top(Infinity), attrId);
+              _.pluck(this.invisibleDimension.top(Infinity), attrId).sort();
           }
         }
         if (_selectedCases.length === 0) {
@@ -245,7 +245,7 @@
             name: 'Selected Patients'
           }, {
             id: 1,
-            caseIds: _.difference(
+            caseIds: iViz.util.difference(
               _allCases, _selectedCases),
             curveHex: '#2986e2',
             name: 'Unselected Patients'


### PR DESCRIPTION
Only sort caseUids once;
Use sorted difference method;
Use nonNaCases.push.apply instead of concat. concat creates new array
which uses lots of memory and causing GC. Based on
https://stackoverflow.com/questions/5080028/what-is-the-most-efficient-w
ay-to-concatenate-n-arrays-in-javascript.