### PR TITLE
Use sample list when fetching sampe gene panel info

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -394,19 +394,14 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
         });
       return def.promise();
     },
-    extractMutationData: function(_mutationData) {
+    extractMutationData: function(_mutationData, _allSamples) {
       var _mutGeneMeta = {};
-      var _allMutSamples = {};
       var _allMutGenes = _.pluck(_mutationData, 'gene_symbol');
       var _mutGeneMetaIndex = 0;
       var self = this;
       _.each(_mutationData, function(_mutGeneDataObj) {
         var _uniqueId = _mutGeneDataObj.gene_symbol;
-        if (!_allMutSamples.hasOwnProperty(_mutGeneDataObj.study_id)) {
-          _allMutSamples[_mutGeneDataObj.study_id] = {};
-        }
         _.each(_mutGeneDataObj.caseIds, function(_caseId) {
-          _allMutSamples[_mutGeneDataObj.study_id][_caseId] = 1;
           var _caseUIdIndex = self.getCaseIndex('sample', _mutGeneDataObj.study_id, _caseId);
           if (_mutGeneMeta[_uniqueId] === undefined) {
             _mutGeneMeta[_uniqueId] = {};
@@ -442,8 +437,8 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
       tableData_.mutated_genes.allGenes = _allMutGenes;
       tableData_.mutated_genes.allSamples = [];
 
-      _.each(_allMutSamples, function(samples, studyId) {
-        _.each(Object.keys(samples), function(sampleId) {
+      _.each(_allSamples, function(samples, studyId) {
+        _.each(samples, function(sampleId) {
           tableData_.mutated_genes.allSamples.push({
             "molecularProfileId": window.iviz.datamanager.getMutationProfileIdByStudyId(studyId),
             "sampleId": sampleId
@@ -452,16 +447,12 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
       });
       return tableData_.mutated_genes;
     },
-    extractCnaData: function(_cnaData) {
+    extractCnaData: function(_cnaData, _allSamples) {
       var _cnaMeta = {};
-      var _allCNASamples = {};
       var _allCNAGenes = {};
       var _cnaMetaIndex = 0;
       var self = this;
       $.each(_cnaData, function(_studyId, _cnaDataPerStudy) {
-        if (!_allCNASamples.hasOwnProperty(_studyId)) {
-          _allCNASamples[_studyId] = {};
-        }
         $.each(_cnaDataPerStudy.caseIds, function(_index, _caseIdsPerGene) {
           var _geneSymbol = _cnaDataPerStudy.gene[_index];
           var _altType = '';
@@ -478,7 +469,6 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
           }
           var _uniqueId = _geneSymbol + '-' + _altType;
           _.each(_caseIdsPerGene, function(_caseId) {
-            _allCNASamples[_studyId][_caseId] = 1;
             var _caseIdIndex = self.getCaseIndex('sample', _studyId, _caseId);
             if (_cnaMeta[_uniqueId] === undefined) {
               _cnaMeta[_uniqueId] = {};
@@ -519,8 +509,8 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
       tableData_.cna_details.allGenes = Object.keys(_allCNAGenes);
       tableData_.cna_details.allSamples = [];
 
-      _.each(_allCNASamples, function(samples, studyId) {
-        _.each(Object.keys(samples), function(sampleId) {
+      _.each(_allSamples, function(samples, studyId) {
+        _.each(samples, function(sampleId) {
           tableData_.cna_details.allSamples.push({
             "molecularProfileId": window.iviz.datamanager.getCNAProfileIdByStudyId(studyId),
             "sampleId": sampleId
@@ -536,14 +526,14 @@ window.iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
         if (attrId === 'mutated_genes') {
           $.when(window.iviz.datamanager.getMutData(progressFunc))
             .then(function(_data) {
-              def.resolve(self.extractMutationData(_data));
+              def.resolve(self.extractMutationData(_data, window.iviz.datamanager.getAllMutatedGeneSamples()));
             }, function() {
               def.reject();
             });
         } else if (attrId === 'cna_details') {
           $.when(window.iviz.datamanager.getCnaData(progressFunc))
             .then(function(_data) {
-              def.resolve(self.extractCnaData(_data));
+              def.resolve(self.extractCnaData(_data, window.iviz.datamanager.getAllCNASamples()));
             }, function() {
               def.reject();
             });

--- a/app/scripts/model/dataProxy.js
+++ b/app/scripts/model/dataProxy.js
@@ -945,12 +945,15 @@ window.DataManagerForIviz = (function($, _) {
                 // Always check for all lists, the API call may fail partially
                 if (_.isArray(self.data.sampleLists[studyId][studyId + '_sequenced'])) {
                   _responseStudyCaseList[studyId].sequencedSampleIds = iViz.util.intersection(self.data.sampleLists[studyId][studyId + '_sequenced'], self.studyCasesMap[studyId].samples);
+                  self.data.sampleLists.sequenced[studyId] = _responseStudyCaseList[studyId].sequencedSampleIds;
                 }
                 if (_.isArray(self.data.sampleLists[studyId][studyId + '_cna'])) {
                   _responseStudyCaseList[studyId].cnaSampleIds = iViz.util.intersection(self.data.sampleLists[studyId][studyId + '_cna'], self.studyCasesMap[studyId].samples);
+                  self.data.sampleLists.cna[studyId] = _responseStudyCaseList[studyId].cnaSampleIds;
                 }
                 if (_.isArray(self.data.sampleLists[studyId][studyId + '_all'])) {
                   _responseStudyCaseList[studyId].allSampleIds = iViz.util.intersection(self.data.sampleLists[studyId][studyId + '_all'], self.studyCasesMap[studyId].samples);
+                  self.data.sampleLists.all[studyId] = _responseStudyCaseList[studyId].allSampleIds;
                 }
               });
               fetch_promise.resolve(_responseStudyCaseList);
@@ -1213,6 +1216,22 @@ window.DataManagerForIviz = (function($, _) {
             def.reject(error);
           });
         return def.promise();
+      },
+      getAllMutatedGeneSamples: function() {
+        var samples = {};
+        var self = this;
+        _.each(Object.keys(self.studyCasesMap), function(studyId) {
+          samples[studyId] = self.data.sampleLists.sequenced[studyId] || self.data.sampleLists.all[studyId]
+        });
+        return samples;
+      },
+      getAllCNASamples: function() {
+        var samples = {};
+        var self = this;
+        _.each(Object.keys(self.studyCasesMap), function(studyId) {
+          samples[studyId] = self.data.sampleLists.cna[studyId] || self.data.sampleLists.all[studyId]
+        });
+        return samples;
       },
       getCnaFractionData: window.cbio.util.makeCachedPromiseFunction(
         function(self, fetch_promise) {


### PR DESCRIPTION
The new gene panel endpoint returns whether the sample is profiled. No longer need to prefiltering the samples anymore which causing issue because we use all samples with mutation